### PR TITLE
Change the sections data structure.

### DIFF
--- a/letterparser/parse.py
+++ b/letterparser/parse.py
@@ -1,4 +1,5 @@
 import re
+from collections import OrderedDict
 import pypandoc
 from letterparser import utils
 
@@ -47,7 +48,7 @@ def convert_break_tags(jats_content, root_tag="root"):
     break_section_map = {"": break_section_match}
     break_sections = sections(jats_content, root_tag, break_section_map)
     for i, break_section in enumerate(break_sections):
-        content = list(break_section.values())[0]
+        content = break_section.get("content")
         content = content.replace(break_section_match, "")
         if i != 0:
             converted_jats_content += "<p>"
@@ -87,7 +88,9 @@ def sections(jats_content, root_tag="root", section_map=None):
         # set the section type based on the match string
         portion_section_type = section_type(portion, section_map)
         # populate the section
-        section = {portion_section_type: portion}
+        section = OrderedDict()
+        section["section_type"] = portion_section_type
+        section["content"] = portion
         # append it if not empty
         if portion:
             sections.append(section)

--- a/tests/fixtures/dutzler_39122_sections.py
+++ b/tests/fixtures/dutzler_39122_sections.py
@@ -1,8 +1,14 @@
 # coding=utf-8
-
+from collections import OrderedDict
 from tests import read_fixture
 
 EXPECTED = [
-    {'decision_letter': read_fixture('dutzler_39122_section_1.txt')},
-    {'author_response': read_fixture('dutzler_39122_section_2.txt')}
+    OrderedDict([
+        ('section_type', 'decision_letter'),
+        ('content', read_fixture('dutzler_39122_section_1.txt'))
+    ]),
+    OrderedDict([
+        ('section_type', 'author_response'),
+        ('content', read_fixture('dutzler_39122_section_2.txt'))
+    ])
 ]

--- a/tests/fixtures/sections_sections.py
+++ b/tests/fixtures/sections_sections.py
@@ -1,5 +1,17 @@
+from collections import OrderedDict
+
+
 EXPECTED = [
-    {'preamble': '<p><bold>Preamble</bold></p><p>Preamble ....</p>'},
-    {'decision_letter': '<p><bold>Decision letter</bold></p><p>Decision letter ....</p>'},
-    {'author_response': '<p><bold>Author response</bold></p><p>Author response ....</p>'}
+    OrderedDict([
+        ('section_type', 'preamble'),
+        ('content', '<p><bold>Preamble</bold></p><p>Preamble ....</p>')
+    ]),
+    OrderedDict([
+        ('section_type', 'decision_letter'),
+        ('content', '<p><bold>Decision letter</bold></p><p>Decision letter ....</p>')
+    ]),
+    OrderedDict([
+        ('section_type', 'author_response'),
+        ('content', '<p><bold>Author response</bold></p><p>Author response ....</p>')
+    ])
 ]


### PR DESCRIPTION
Follow-up to PR https://github.com/elifesciences/decision-letter-parser/pull/19, I want to use this more straight-forward data structure for the sections, where `section_type` is a key.