### PR TITLE
Python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ dist: xenial
 language: python
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py27
     - python: 3.5
       env: TOXENV=py35
 before_install:

--- a/letterparser/parse.py
+++ b/letterparser/parse.py
@@ -15,7 +15,7 @@ def raw_jats(file_name, root_tag="root"):
     "convert file content to JATS"
     jats_content = ""
     output = pypandoc.convert_file(file_name, "jats")
-    jats_content = "<%s>%s</%s>" % (root_tag, utils.unicode_encode(output), root_tag)
+    jats_content = "<%s>%s</%s>" % (root_tag, output, root_tag)
     return jats_content
 
 

--- a/letterparser/utils.py
+++ b/letterparser/utils.py
@@ -15,22 +15,6 @@ REPARSING_NAMESPACES = (
 )
 
 
-def unicode_encode(string):
-    "encode to utf8 depending on the python version"
-    if sys.version_info[0] < 3:
-        string = string.encode('utf8')
-    return string
-
-
-def unicode_decode(string):
-    "try to decode from utf8"
-    try:
-        string = string.decode('utf8')
-    except (UnicodeEncodeError, AttributeError):
-        pass
-    return string
-
-
 def remove_non_breaking_space(string):
     """replace non breaking space characters"""
     return string.replace("\xc2\xa0", "").replace("\xa0", "")
@@ -102,6 +86,6 @@ def append_to_parent_tag(parent, tag_name, original_string,
     tag_converted_string = etoolsutils.escape_unmatched_angle_brackets(
         tag_converted_string, allowed_tags())
     minidom_tag = xmlio.reparsed_tag(
-        tag_name, unicode_decode(tag_converted_string), namespaces, attributes_text)
+        tag_name, tag_converted_string, namespaces, attributes_text)
     xmlio.append_minidom_xml_to_elementtree_xml(
         parent, minidom_tag, attributes=attributes, child_attributes=True)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='letterparser',
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         ]
     )


### PR DESCRIPTION
Fixes https://github.com/elifesciences/decision-letter-parser/issues/25

Turning off testing for Python 2, removing functions that provided better Python 2 support.

It should be ok to merge if tests are green.