### PR TITLE
Remove py27 tests from tox.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py27,py35
+envlist = py35
 [testenv]
 deps = -rrequirements.txt
 whitelist_externals = coverage


### PR DESCRIPTION
Follow-up to PR https://github.com/elifesciences/decision-letter-parser/pull/26, I forgot to remove py27 from tox tests.