### PR TITLE
Install coverage for project tests.

### DIFF
--- a/project_tests.sh
+++ b/project_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-pip install coveralls
 tox
 . .tox/py35/bin/activate
+pip install coveralls
 COVERALLS_REPO_TOKEN=$(cat /etc/coveralls/tokens/decision-letter-parser) coveralls
 

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
+pip install coveralls
 tox
 . .tox/py35/bin/activate
-pip install coverage
-pip install coveralls
 COVERALLS_REPO_TOKEN=$(cat /etc/coveralls/tokens/decision-letter-parser) coveralls
 

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -2,6 +2,7 @@
 
 tox
 . .tox/py35/bin/activate
+pip install coverage
 pip install coveralls
 COVERALLS_REPO_TOKEN=$(cat /etc/coveralls/tokens/decision-letter-parser) coveralls
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 skipsdist = True
 envlist = py35
 [testenv]
-deps = -rrequirements.txt
+deps = 
+    coverage
+    -rrequirements.txt
 whitelist_externals = coverage
 commands = coverage run -m pytest


### PR DESCRIPTION
Re issue https://github.com/elifesciences/decision-letter-parser/issues/6, I think this is one way so `coverage` is available when running tests. The travis-ci tests seem to not need this because `coveralls` is installed before `tox` is invoked.