### PR TITLE
Kitchen sink XML generation

### DIFF
--- a/letterparser/generate.py
+++ b/letterparser/generate.py
@@ -54,8 +54,8 @@ def generate(articles, root_tag="root"):
 def id_prefix(tag_name):
     """return the id attribute prefix for the tag name"""
     id_prefix_map = {
-        "mml:math": "m",
-        "disp-formula": "equ",
+        "mml:math": "respm",
+        "disp-formula": "respequ",
         "fig": "respfig",
         "table-wrap": "resptable",
         "media": "respvideo"

--- a/letterparser/generate.py
+++ b/letterparser/generate.py
@@ -35,6 +35,7 @@ def generate(articles, root_tag="root"):
     root = Element(root_tag)
     # set namespaces
     root.set('xmlns:mml', 'http://www.w3.org/1998/Math/MathML')
+    root.set('xmlns:xlink', 'http://www.w3.org/1999/xlink')
     for article in articles:
         sub_article_tag = SubElement(root, "sub-article")
         set_if_value(sub_article_tag, "article-type", article.article_type)

--- a/letterparser/generate.py
+++ b/letterparser/generate.py
@@ -66,7 +66,8 @@ def set_content_blocks(parent, content_blocks, level=1):
         raise Exception('Maximum level of nested content blocks reached')
     for block in content_blocks:
         block_tag = None
-        if block.block_type in ["boxed-text", "disp-formula", "disp-quote", "list", "p"]:
+        if block.block_type in ["boxed-text", "disp-formula", "disp-quote", "fig",
+                                "list", "media", "p", "table-wrap"]:
             # retain standard tag attributes as well as any specific ones from the block object
             if block.content:
                 utils.append_to_parent_tag(

--- a/letterparser/generate.py
+++ b/letterparser/generate.py
@@ -74,11 +74,14 @@ def set_id_attributes(root, tag_name):
 
 def set_front_stub(parent, article):
     front_stub_tag = SubElement(parent, "front-stub")
+    if article.doi:
+        doi_tag = SubElement(front_stub_tag, "article-id")
+        doi_tag.set("pub-id-type", "doi")
+        doi_tag.text = article.doi
     if article.title:
         title_group_tag = SubElement(front_stub_tag, "title-group")
         article_title_tag = SubElement(title_group_tag, "article-title")
         article_title_tag.text = article.title
-    # todo!!! continue to fill in the front-stub tag
 
 
 def set_body(parent, article):

--- a/letterparser/generate.py
+++ b/letterparser/generate.py
@@ -42,8 +42,34 @@ def generate(articles, root_tag="root"):
         set_if_value(sub_article_tag, "id", article.id)
         set_front_stub(sub_article_tag, article)
         set_body(sub_article_tag, article)
-    # todo!!!! - set mml:math tag id attributes
+    # set tag id attributes
+    set_id_attributes(root, "mml:math")
+    set_id_attributes(root, "disp-formula")
+    set_id_attributes(root, "fig")
+    set_id_attributes(root, "table-wrap")
+    set_id_attributes(root, "media")
     return root
+
+
+def id_prefix(tag_name):
+    """return the id attribute prefix for the tag name"""
+    id_prefix_map = {
+        "mml:math": "m",
+        "disp-formula": "equ",
+        "fig": "respfig",
+        "table-wrap": "resptable",
+        "media": "respvideo"
+    }
+    return str(id_prefix_map.get(tag_name))
+
+
+def set_id_attributes(root, tag_name):
+    """set the id attribute of tags"""
+    i = 1
+    for tag in root.iter(tag_name):
+        if "id" not in tag.attrib:
+            tag.set("id", "%s%s" % (id_prefix(tag_name), i))
+            i += 1
 
 
 def set_front_stub(parent, article):

--- a/letterparser/generate.py
+++ b/letterparser/generate.py
@@ -76,6 +76,8 @@ def set_content_blocks(parent, content_blocks, level=1):
                 # add empty tags too
                 block_tag = SubElement(parent, block.block_type)
                 block_tag.text = block.content
+                for key, value in block.attr.items():
+                    block_tag.set(key, value)
         if block_tag is not None and block.content_blocks:
             # recursion
             set_content_blocks(block_tag, block.content_blocks, level+1)

--- a/letterparser/utils.py
+++ b/letterparser/utils.py
@@ -92,6 +92,15 @@ def allowed_tags():
         '<ext-link', '</ext-link>',
         '<list', '</list>',
         '<list-item', '</list-item>',
+        '<label>', '</label>',
+        '<caption>', '</caption>',
+        '<graphic', '</graphic>',
+        '<table', '</table>',
+        '<thead>', '</thead>',
+        '<tbody>', '</tbody>',
+        '<tr>', '</tr>',
+        '<th>', '</th>',
+        '<td', '</td>',
     )
 
 

--- a/letterparser/utils.py
+++ b/letterparser/utils.py
@@ -85,6 +85,7 @@ def allowed_tags():
         '<tr>', '</tr>',
         '<th>', '</th>',
         '<td', '</td>',
+        '<xref', '</xref>'
     )
 
 

--- a/tests/fixtures/generate_simple.xml
+++ b/tests/fixtures/generate_simple.xml
@@ -25,7 +25,7 @@
         </front-stub>
         <body>
             <p>Essential revisions:</p>
-            <disp-quote>
+            <disp-quote content-type="editor-comment">
                 <p>1) I am not sure that I understand ....</p>
             </disp-quote>
         </body>

--- a/tests/fixtures/generate_simple.xml
+++ b/tests/fixtures/generate_simple.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<root xmlns:mml="http://www.w3.org/1998/Math/MathML">
+<root xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
     <sub-article article-type="decision-letter" id="SA1">
         <front-stub>
             <title-group>

--- a/tests/fixtures/kitchen_sink.xml
+++ b/tests/fixtures/kitchen_sink.xml
@@ -32,7 +32,15 @@
                 <p>The reviewers have discussed the reviews with one another and the Reviewing Editor has drafted this decision to help you prepare a revised submission.</p>
                 <p>You need to make sure the XML structure you creates works on the display of the PMC platform and also that there is enough information contained within the tagging togenerate a typeset PDF from the XML with no additional information provided.</p>
             </disp-quote>
-            <p>In response to this comment, we validated the XML against the DTD (JATS 1) each time we made an update. We also regularly used the PMC validator to check our decisions against display on the PMC site, see Author response image 1., Author response video 1 and Author response table 1.</p>
+            <p>
+                In response to this comment, we validated the XML against the DTD (JATS 1) each time we made an update. We also regularly used the PMC validator to check our decisions against display on the PMC site, see 
+                <xref ref-type="fig" rid="respfig1">Author response image 1.</xref>
+                , 
+                <xref ref-type="video" rid="respvideo1">Author response video 1</xref>
+                 and 
+                <xref ref-type="table" rid="resptable1">Author response table 1</xref>
+                .
+            </p>
             <fig id="respfig1">
                 <label>Author response image 1.</label>
                 <caption>

--- a/tests/fixtures/kitchen_sink.xml
+++ b/tests/fixtures/kitchen_sink.xml
@@ -106,7 +106,7 @@
             <p>
                 Adding some MathML to the sub-article.
                 <inline-formula>
-                    <mml:math id="m1">
+                    <mml:math id="respm1">
                         <mml:mrow>
                             <mml:munder>
                                 <mml:mo/>
@@ -129,8 +129,8 @@
             </p>
             <p>
                 May also contain a formula as a block
-                <disp-formula id="equ1">
-                    <mml:math id="m2" xmlns:mml="http://www.w3.org/1998/Math/MathML">
+                <disp-formula id="respequ1">
+                    <mml:math id="respm2" xmlns:mml="http://www.w3.org/1998/Math/MathML">
                         <mml:mrow>
                             <mml:mi>ϕ</mml:mi>
                             <mml:mo>=</mml:mo>

--- a/tests/fixtures/kitchen_sink.xml
+++ b/tests/fixtures/kitchen_sink.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <sub-article article-type="decision-letter" id="SA1">
+        <front-stub>
+            <title-group>
+                <article-title>Decision letter</article-title>
+            </title-group>
+        </front-stub>
+        <body>
+            <boxed-text>
+                <p>In the interests of transparency, eLife includes the editorial decision letter and accompanying author responses. A lightly edited version of the letter sent to the authors after peer review is shown, indicating the most substantive concerns; minor comments are not usually included.</p>
+            </boxed-text>
+            <p>
+                Thank you for submitting your article &quot;The eLife research article&quot; for consideration by 
+                <italic>eLife</italic>
+                . Your article has been reviewed by three peer reviewers, one of whom, Joe Bloggs, is a member of our editorial board and also oversaw the process as Senior editor. John Doe (peer reviewer) has agreed to reveal his identity.
+            </p>
+            <p>The reviewers have discussed the reviews with one another and the Reviewing Editor has drafted this decision to help you prepare a revised submission.</p>
+            <p>You need to make sure the XML structure you creates works on the display of the PMC platform and also that there is enough information contained within the tagging to generate a typeset PDF from the XML with no additional information provided.</p>
+        </body>
+    </sub-article>
+    <sub-article article-type="reply" id="SA2">
+        <front-stub>
+            <title-group>
+                <article-title>Author response</article-title>
+            </title-group>
+        </front-stub>
+        <body>
+            <disp-quote content-type="editor-comment">
+                <p>The reviewers have discussed the reviews with one another and the Reviewing Editor has drafted this decision to help you prepare a revised submission.</p>
+                <p>You need to make sure the XML structure you creates works on the display of the PMC platform and also that there is enough information contained within the tagging togenerate a typeset PDF from the XML with no additional information provided.</p>
+            </disp-quote>
+            <p>In response to this comment, we validated the XML against the DTD (JATS 1) each time we made an update. We also regularly used the PMC validator to check our decisions against display on the PMC site, see Author response image 1., Author response video 1 and Author response table 1.</p>
+            <fig id="respfig1" position="float">
+                <label>Author response image 1.</label>
+                <caption>
+                    <p>Single figure: The header of an eLife article example on the HTML page.</p>
+                </caption>
+                <graphic mime-subtype="tiff" mimetype="image" xlink:href="elife-00666-resp-fig1.tif"/>
+            </fig>
+            <table-wrap id="resptable1" position="float">
+                <label>Author response Table 1.</label>
+                <caption>
+                    <p>Author response table</p>
+                </caption>
+                <table frame="hsides" rules="groups">
+                    <thead>
+                        <tr>
+                            <th>Sample</th>
+                            <th>Same</th>
+                            <th>Difference more than 10%</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>DKO1.cell.1</td>
+                            <td>77.00%</td>
+                            <td>6.90%</td>
+                        </tr>
+                        <tr>
+                            <td>DKO1.cell.2</td>
+                            <td>78.80%</td>
+                            <td>7.20%</td>
+                        </tr>
+                        <tr>
+                            <td>DKO1.cell.3</td>
+                            <td>79.10%</td>
+                            <td>6.70%</td>
+                        </tr>
+                        <tr>
+                            <td>DKO1.exo.1</td>
+                            <td>78.90%</td>
+                            <td>6.50%</td>
+                        </tr>
+                        <tr>
+                            <td>DKO1.exo.2</td>
+                            <td>80.00%</td>
+                            <td>5.80%</td>
+                        </tr>
+                        <tr>
+                            <td>DKO1.exo.3</td>
+                            <td>86.80%</td>
+                            <td>2.30%</td>
+                        </tr>
+                        <tr>
+                            <td>DKS8.cell.1</td>
+                            <td>77.30%</td>
+                            <td>7.80%</td>
+                        </tr>
+                        <tr>
+                            <td>DKS8.cell.2</td>
+                            <td>79.70%</td>
+                            <td>6.70%</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </table-wrap>
+            <media id="respvideo1" mime-subtype="mp4" mimetype="video" xlink:href="elife-00666-resp-video1.mp4">
+                <label>Author response video 1.</label>
+                <caption>
+                    <p>Caption and/or a title is required for all author response assets</p>
+                </caption>
+            </media>
+            <p>However, some decisions required some communication with PMC to discuss whether any of our updates could be accomodated by them - during this review we aimed to reduce the complexity of the XML structure and remove all formatting and bioler plate text required for a PDF display format. We also produced buisness rules {Insert table} in order to produce rules for the production systems and the website to follow. These buisness rules also informed the basis for a set of Schematron rules for our references.{Insert table}</p>
+            <p>If an author referes to a reference in the response letter it is cross linked to the reference in the reference list (Coyne and Orr, 1989), however, if it is a new reference only cited in the decision letter or author response it is not added to the main reference link and is just listed as free text, for example, Butcher et al, 2006. If the author provides the reference it can be added as free text to the end of the letter, however, this is not a requirement.</p>
+            <p>
+                Adding some MathML to the sub-article.
+                <inline-formula>
+                    <mml:math>
+                        <mml:mrow>
+                            <mml:munder>
+                                <mml:mo/>
+                                <mml:mi>m</mml:mi>
+                            </mml:munder>
+                            <mml:mrow>
+                                <mml:msub>
+                                    <mml:mover accent="true">
+                                        <mml:mi>p</mml:mi>
+                                        <mml:mo/>
+                                    </mml:mover>
+                                    <mml:mi>m</mml:mi>
+                                </mml:msub>
+                                <mml:mo>=</mml:mo>
+                                <mml:mn>0</mml:mn>
+                            </mml:mrow>
+                        </mml:mrow>
+                    </mml:math>
+                </inline-formula>
+            </p>
+            <p>
+                May also contain a formula as a block
+                <disp-formula>
+                    <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML">
+                        <mml:mrow>
+                            <mml:mi>ϕ</mml:mi>
+                            <mml:mo>=</mml:mo>
+                            <mml:msup>
+                                <mml:mi>e</mml:mi>
+                                <mml:mrow>
+                                    <mml:mo>−</mml:mo>
+                                    <mml:mfrac>
+                                        <mml:mtext mathvariant="normal">zFV</mml:mtext>
+                                        <mml:mtext mathvariant="normal">nRT</mml:mtext>
+                                    </mml:mfrac>
+                                </mml:mrow>
+                            </mml:msup>
+                        </mml:mrow>
+                    </mml:math>
+                </disp-formula>
+            </p>
+            <list list-type="order">
+                <list-item>
+                    <p>'Contamination'</p>
+                    <list list-type="roman-lower">
+                        <list-item>
+                            <p>
+                                Cell line 
+                                <sup>superscript</sup>
+                                <sub>subscript</sub>
+                                 &amp; p&lt;0.001
+                            </p>
+                        </list-item>
+                        <list-item>
+                            <p>
+                                <italic>C. elegans</italic>
+                            </p>
+                        </list-item>
+                    </list>
+                </list-item>
+            </list>
+        </body>
+    </sub-article>
+</root>

--- a/tests/fixtures/kitchen_sink.xml
+++ b/tests/fixtures/kitchen_sink.xml
@@ -2,6 +2,7 @@
 <root xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
     <sub-article article-type="decision-letter" id="SA1">
         <front-stub>
+            <article-id pub-id-type="doi">10.7554/eLife.00666.DL</article-id>
             <title-group>
                 <article-title>Decision letter</article-title>
             </title-group>
@@ -21,6 +22,7 @@
     </sub-article>
     <sub-article article-type="reply" id="SA2">
         <front-stub>
+            <article-id pub-id-type="doi">10.7554/eLife.00666.AR</article-id>
             <title-group>
                 <article-title>Author response</article-title>
             </title-group>

--- a/tests/fixtures/kitchen_sink.xml
+++ b/tests/fixtures/kitchen_sink.xml
@@ -31,14 +31,14 @@
                 <p>You need to make sure the XML structure you creates works on the display of the PMC platform and also that there is enough information contained within the tagging togenerate a typeset PDF from the XML with no additional information provided.</p>
             </disp-quote>
             <p>In response to this comment, we validated the XML against the DTD (JATS 1) each time we made an update. We also regularly used the PMC validator to check our decisions against display on the PMC site, see Author response image 1., Author response video 1 and Author response table 1.</p>
-            <fig id="respfig1" position="float">
+            <fig id="respfig1">
                 <label>Author response image 1.</label>
                 <caption>
                     <p>Single figure: The header of an eLife article example on the HTML page.</p>
                 </caption>
                 <graphic mime-subtype="tiff" mimetype="image" xlink:href="elife-00666-resp-fig1.tif"/>
             </fig>
-            <table-wrap id="resptable1" position="float">
+            <table-wrap id="resptable1">
                 <label>Author response Table 1.</label>
                 <caption>
                     <p>Author response table</p>
@@ -106,7 +106,7 @@
             <p>
                 Adding some MathML to the sub-article.
                 <inline-formula>
-                    <mml:math>
+                    <mml:math id="m1">
                         <mml:mrow>
                             <mml:munder>
                                 <mml:mo/>
@@ -129,8 +129,8 @@
             </p>
             <p>
                 May also contain a formula as a block
-                <disp-formula>
-                    <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML">
+                <disp-formula id="equ1">
+                    <mml:math id="m2" xmlns:mml="http://www.w3.org/1998/Math/MathML">
                         <mml:mrow>
                             <mml:mi>ϕ</mml:mi>
                             <mml:mo>=</mml:mo>

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,18 @@
+from elifearticle.article import Article
+
+
+def base_sub_article(title, article_type, article_id):
+    sub_article = Article(None, title)
+    sub_article.article_type = article_type
+    sub_article.id = article_id
+    # dynamically set content_blocks until this property is added to the Article object properly
+    sub_article.content_blocks = []
+    return sub_article
+
+
+def base_decision_letter():
+    return base_sub_article("Decision letter", "decision-letter", "SA1",)
+
+
+def base_author_response():
+    return base_sub_article("Author response", "reply", "SA2")

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -2,31 +2,13 @@
 
 import unittest
 from xml.etree.ElementTree import Element
-from elifearticle.article import Article
 from letterparser import generate
 from letterparser.objects import ContentBlock
-from tests import data_path, read_fixture
-
-
-def base_sub_article(title, article_type, article_id):
-    sub_article = Article(None, title)
-    sub_article.article_type = article_type
-    sub_article.id = article_id
-    # dynamically set content_blocks until this property is added to the Article object properly
-    sub_article.content_blocks = []
-    return sub_article
-
-
-def base_decision_letter():
-    return base_sub_article("Decision letter", "decision-letter", "SA1",)
-
-
-def base_author_response():
-    return base_sub_article("Author response", "reply", "SA2")
+from tests import data_path, helpers, read_fixture
 
 
 def simple_decision_letter():
-    sub_article = base_decision_letter()
+    sub_article = helpers.base_decision_letter()
     preamble_block = ContentBlock("boxed-text")
     preamble_block.content_blocks.append(ContentBlock("p", "Preamble"))
     sub_article.content_blocks.append(preamble_block)
@@ -36,7 +18,7 @@ def simple_decision_letter():
 
 
 def simple_author_response():
-    sub_article = base_author_response()
+    sub_article = helpers.base_author_response()
     sub_article.content_blocks.append(ContentBlock("p", "Essential revisions:"))
     disp_quote_block = ContentBlock("disp-quote")
     disp_quote_block.attr["content-type"] = "editor-comment"
@@ -82,7 +64,7 @@ class TestGenerateMaxLevel(unittest.TestCase):
         max_level_original = generate.MAX_LEVEL
         generate.MAX_LEVEL = 1
         # add two levels of nested content
-        article = base_decision_letter()
+        article = helpers.base_decision_letter()
         parent_block = ContentBlock("p", "First level paragraph.")
         child_block = ContentBlock("p", "Second level paragraph.")
         parent_block.content_blocks.append(child_block)

--- a/tests/test_generate_kitchen_sink.py
+++ b/tests/test_generate_kitchen_sink.py
@@ -55,15 +55,12 @@ def kitchen_sink_author_response():
         " against display on the PMC site, see Author response image 1., Author response video 1" +
         " and Author response table 1.")))
 
-    fig_block = ContentBlock("fig", (
+    sub_article.content_blocks.append(ContentBlock("fig", (
         "<label>Author response image 1.</label><caption><p>Single figure: The header of an" +
         ' eLife article example on the HTML page.</p></caption><graphic mimetype="image"' +
-        ' mime-subtype="tiff" xlink:href="elife-00666-resp-fig1.tif"/>'))
-    fig_block.attr["id"] = "respfig1"
-    fig_block.attr["position"] = "float"
-    sub_article.content_blocks.append(fig_block)
+        ' mime-subtype="tiff" xlink:href="elife-00666-resp-fig1.tif"/>')))
 
-    table_block = ContentBlock("table-wrap", (
+    sub_article.content_blocks.append(ContentBlock("table-wrap", (
         "<label>Author response Table 1.</label><caption><p>Author response table</p></caption>" +
         '<table frame="hsides" rules="groups"><thead>' +
         '<tr><th>Sample</th><th>Same</th><th>Difference more than 10%</th></tr>' +
@@ -76,17 +73,13 @@ def kitchen_sink_author_response():
         '<tr><td>DKO1.exo.3</td><td>86.80%</td><td>2.30%</td></tr>' +
         '<tr><td>DKS8.cell.1</td><td>77.30%</td><td>7.80%</td></tr>' +
         '<tr><td>DKS8.cell.2</td><td>79.70%</td><td>6.70%</td></tr>' +
-        '</tbody></table>'))
-    table_block.attr["id"] = "resptable1"
-    table_block.attr["position"] = "float"
-    sub_article.content_blocks.append(table_block)
+        '</tbody></table>')))
 
     media_block = ContentBlock("media", (
         "<label>Author response video 1.</label><caption><p>Caption and/or a title is required" +
         " for all author response assets</p></caption>"))
     media_block.attr["mimetype"] = "video"
     media_block.attr["mime-subtype"] = "mp4"
-    media_block.attr["id"] = "respvideo1"
     media_block.attr["xlink:href"] = "elife-00666-resp-video1.mp4"
     sub_article.content_blocks.append(media_block)
 

--- a/tests/test_generate_kitchen_sink.py
+++ b/tests/test_generate_kitchen_sink.py
@@ -54,8 +54,10 @@ def kitchen_sink_author_response():
     sub_article.content_blocks.append(ContentBlock("p", (
         "In response to this comment, we validated the XML against the DTD (JATS 1) each time" +
         " we made an update. We also regularly used the PMC validator to check our decisions" +
-        " against display on the PMC site, see Author response image 1., Author response video 1" +
-        " and Author response table 1.")))
+        ' against display on the PMC site, see <xref ref-type="fig" rid="respfig1">' +
+        'Author response image 1.</xref>, <xref ref-type="video" rid="respvideo1">' +
+        'Author response video 1</xref> and <xref ref-type="table" rid="resptable1">' +
+        "Author response table 1</xref>.")))
 
     sub_article.content_blocks.append(ContentBlock("fig", (
         "<label>Author response image 1.</label><caption><p>Single figure: The header of an" +

--- a/tests/test_generate_kitchen_sink.py
+++ b/tests/test_generate_kitchen_sink.py
@@ -1,0 +1,146 @@
+# coding=utf-8
+
+import unittest
+from letterparser import generate
+from letterparser.objects import ContentBlock
+from tests import helpers, read_fixture
+
+
+def kitchen_sink_decision_letter():
+    sub_article = helpers.base_decision_letter()
+
+    preamble_block = ContentBlock("boxed-text")
+    preamble_block.content_blocks.append(ContentBlock("p", (
+        "In the interests of transparency, eLife includes the editorial decision letter" +
+        " and accompanying author responses. A lightly edited version of the letter sent" +
+        " to the authors after peer review is shown, indicating the most substantive concerns;" +
+        " minor comments are not usually included.")))
+    sub_article.content_blocks.append(preamble_block)
+
+    sub_article.content_blocks.append(ContentBlock("p", (
+        'Thank you for submitting your article "The eLife research article" for consideration' +
+        " by <italic>eLife</italic>. Your article has been reviewed by three peer reviewers," +
+        " one of whom, Joe Bloggs, is a member of our editorial board and also oversaw the" +
+        " process as Senior editor. John Doe (peer reviewer) has agreed to reveal his identity.")))
+
+    sub_article.content_blocks.append(ContentBlock("p", (
+        "The reviewers have discussed the reviews with one another and the Reviewing Editor" +
+        " has drafted this decision to help you prepare a revised submission.")))
+
+    sub_article.content_blocks.append(ContentBlock("p", (
+        "You need to make sure the XML structure you creates works on the display of the PMC" +
+        " platform and also that there is enough information contained within the tagging to" +
+        " generate a typeset PDF from the XML with no additional information provided.")))
+
+    return sub_article
+
+
+def kitchen_sink_author_response():
+    sub_article = helpers.base_author_response()
+
+    disp_quote_block = ContentBlock("disp-quote")
+    disp_quote_block.attr["content-type"] = "editor-comment"
+    disp_quote_block.content_blocks.append(ContentBlock("p", (
+        "The reviewers have discussed the reviews with one another and the Reviewing Editor" +
+        " has drafted this decision to help you prepare a revised submission.")))
+    disp_quote_block.content_blocks.append(ContentBlock("p", (
+        "You need to make sure the XML structure you creates works on the display of the PMC" +
+        " platform and also that there is enough information contained within the tagging to" +
+        "generate a typeset PDF from the XML with no additional information provided.")))
+    sub_article.content_blocks.append(disp_quote_block)
+
+    sub_article.content_blocks.append(ContentBlock("p", (
+        "In response to this comment, we validated the XML against the DTD (JATS 1) each time" +
+        " we made an update. We also regularly used the PMC validator to check our decisions" +
+        " against display on the PMC site, see Author response image 1., Author response video 1" +
+        " and Author response table 1.")))
+
+    fig_block = ContentBlock("fig", (
+        "<label>Author response image 1.</label><caption><p>Single figure: The header of an" +
+        ' eLife article example on the HTML page.</p></caption><graphic mimetype="image"' +
+        ' mime-subtype="tiff" xlink:href="elife-00666-resp-fig1.tif"/>'))
+    fig_block.attr["id"] = "respfig1"
+    fig_block.attr["position"] = "float"
+    sub_article.content_blocks.append(fig_block)
+
+    table_block = ContentBlock("table-wrap", (
+        "<label>Author response Table 1.</label><caption><p>Author response table</p></caption>" +
+        '<table frame="hsides" rules="groups"><thead>' +
+        '<tr><th>Sample</th><th>Same</th><th>Difference more than 10%</th></tr>' +
+        '</thead><tbody>' +
+        '<tr><td>DKO1.cell.1</td><td>77.00%</td><td>6.90%</td></tr>' +
+        '<tr><td>DKO1.cell.2</td><td>78.80%</td><td>7.20%</td></tr>' +
+        '<tr><td>DKO1.cell.3</td><td>79.10%</td><td>6.70%</td></tr>' +
+        '<tr><td>DKO1.exo.1</td><td>78.90%</td><td>6.50%</td></tr>' +
+        '<tr><td>DKO1.exo.2</td><td>80.00%</td><td>5.80%</td></tr>' +
+        '<tr><td>DKO1.exo.3</td><td>86.80%</td><td>2.30%</td></tr>' +
+        '<tr><td>DKS8.cell.1</td><td>77.30%</td><td>7.80%</td></tr>' +
+        '<tr><td>DKS8.cell.2</td><td>79.70%</td><td>6.70%</td></tr>' +
+        '</tbody></table>'))
+    table_block.attr["id"] = "resptable1"
+    table_block.attr["position"] = "float"
+    sub_article.content_blocks.append(table_block)
+
+    media_block = ContentBlock("media", (
+        "<label>Author response video 1.</label><caption><p>Caption and/or a title is required" +
+        " for all author response assets</p></caption>"))
+    media_block.attr["mimetype"] = "video"
+    media_block.attr["mime-subtype"] = "mp4"
+    media_block.attr["id"] = "respvideo1"
+    media_block.attr["xlink:href"] = "elife-00666-resp-video1.mp4"
+    sub_article.content_blocks.append(media_block)
+
+    sub_article.content_blocks.append(ContentBlock("p", (
+        "However, some decisions required some communication with PMC to discuss whether any of" +
+        " our updates could be accomodated by them - during this review we aimed to reduce the" +
+        " complexity of the XML structure and remove all formatting and bioler plate text" +
+        " required for a PDF display format. We also produced buisness rules {Insert table}" +
+        " in order to produce rules for the production systems and the website to follow. These" +
+        " buisness rules also informed the basis for a set of Schematron rules for our" +
+        " references.{Insert table}")))
+
+    sub_article.content_blocks.append(ContentBlock("p", (
+        "If an author referes to a reference in the response letter it is cross linked to the" +
+        " reference in the reference list (Coyne and Orr, 1989), however, if it is a new" +
+        " reference only cited in the decision letter or author response it is not added to the" +
+        " main reference link and is just listed as free text, for example, Butcher et al, 2006." +
+        " If the author provides the reference it can be added as free text to the end of the" +
+        " letter, however, this is not a requirement.")))
+
+    sub_article.content_blocks.append(ContentBlock("p", (
+        "Adding some MathML to the sub-article.<inline-formula><mml:math><mml:mrow><mml:munder>" +
+        '<mml:mo/><mml:mi>m</mml:mi></mml:munder><mml:mrow><mml:msub><mml:mover accent="true">' +
+        "<mml:mi>p</mml:mi><mml:mo/></mml:mover><mml:mi>m</mml:mi></mml:msub><mml:mo>=</mml:mo>" +
+        "<mml:mn>0</mml:mn></mml:mrow></mml:mrow></mml:math></inline-formula>")))
+
+    sub_article.content_blocks.append(ContentBlock("p", (
+        'May also contain a formula as a block<disp-formula><mml:math' +
+        ' xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:mi>ϕ</mml:mi>' +
+        '<mml:mo>=</mml:mo><mml:msup><mml:mi>e</mml:mi><mml:mrow><mml:mo>−</mml:mo><mml:mfrac>' +
+        '<mml:mtext mathvariant="normal">zFV</mml:mtext><mml:mtext mathvariant="normal">nRT' +
+        '</mml:mtext></mml:mfrac></mml:mrow></mml:msup></mml:mrow></mml:math></disp-formula>')))
+
+    list_block = ContentBlock("list", (
+        "<list-item><p>'Contamination'</p>" +
+        '<list list-type="roman-lower">' +
+        '<list-item>' +
+        '<p>Cell line <sup>superscript</sup><sub>subscript</sub> &amp; p&lt;0.001</p>' +
+        '</list-item><list-item>' +
+        '<p><italic>C. elegans</italic></p>' +
+        '</list-item>' +
+        '</list></list-item>'))
+    list_block.attr["list-type"] = "order"
+    sub_article.content_blocks.append(list_block)
+
+    return sub_article
+
+
+class TestGenerateKitchenSink(unittest.TestCase):
+
+    def test_generate(self):
+        """test creating kitchen sink XML output"""
+        articles = [kitchen_sink_decision_letter(), kitchen_sink_author_response()]
+        root = generate.generate(articles)
+        pretty_xml = generate.output_xml(root, pretty=True, indent="    ")
+        expected = read_fixture("kitchen_sink.xml", mode="rb")
+        self.assertEqual(pretty_xml, expected)

--- a/tests/test_generate_kitchen_sink.py
+++ b/tests/test_generate_kitchen_sink.py
@@ -8,6 +8,7 @@ from tests import helpers, read_fixture
 
 def kitchen_sink_decision_letter():
     sub_article = helpers.base_decision_letter()
+    sub_article.doi = "10.7554/eLife.00666.DL"
 
     preamble_block = ContentBlock("boxed-text")
     preamble_block.content_blocks.append(ContentBlock("p", (
@@ -37,6 +38,7 @@ def kitchen_sink_decision_letter():
 
 def kitchen_sink_author_response():
     sub_article = helpers.base_author_response()
+    sub_article.doi = "10.7554/eLife.00666.AR"
 
     disp_quote_block = ContentBlock("disp-quote")
     disp_quote_block.attr["content-type"] = "editor-comment"


### PR DESCRIPTION
Fixes https://github.com/elifesciences/decision-letter-parser/issues/22

The result of an experiment to take the content of `Article` objects and generate JATS XML like the eLife `00666` article kitchen sink XML. It is encapsulated in a test scenario which compares the output to an XML file fixture.

To make it work, 
- there are more whitelisted allowed tags, 
- added the `xlink` XML namespace, 
- `@id` attributes of tags are assigned,
- DOI is added to an `<article-id>` tag
- attributes of content block tags are added to the XML output (e.g. `<disp-quote content-type="editor-comment">`)
