### PR TITLE
Fallback, use docker for pandoc call.

### DIFF
--- a/letterparser/docker_lib.py
+++ b/letterparser/docker_lib.py
@@ -1,0 +1,23 @@
+import docker
+from letterparser import utils
+
+
+DOCKER_IMAGE = "knsit/pandoc:v2.5"
+
+
+def get_docker_client():
+    return docker.from_env()
+
+
+def create_docker_volumes_dict(source_path, bind_path='/data', mode='ro'):
+    return {source_path: {'bind': bind_path, 'mode': mode}}
+
+
+def call_pandoc(file_name, output_format="jats"):
+    client = get_docker_client()
+    file_name_path = utils.get_file_name_path(file_name)
+    file_name_file = utils.get_file_name_file(file_name)
+    volumes = create_docker_volumes_dict(file_name_path)
+    command = 'pandoc "/data/%s" -t %s' % (file_name_file, output_format)
+    output = client.containers.run(DOCKER_IMAGE, command, volumes=volumes)
+    return output.decode('utf8')

--- a/letterparser/parse.py
+++ b/letterparser/parse.py
@@ -1,7 +1,7 @@
 import re
 from collections import OrderedDict
 import pypandoc
-from requests.exceptions import ConnectionError
+import requests
 from letterparser import docker_lib, utils
 
 
@@ -23,7 +23,7 @@ def pandoc_output(file_name):
 def docker_pandoc_output(file_name):
     try:
         return docker_lib.call_pandoc(file_name)
-    except ConnectionError:
+    except requests.exceptions.ConnectionError:
         # todo !! log exception - docker may not be running
         pass
 

--- a/letterparser/parse.py
+++ b/letterparser/parse.py
@@ -1,7 +1,8 @@
 import re
 from collections import OrderedDict
 import pypandoc
-from letterparser import utils
+from requests.exceptions import ConnectionError
+from letterparser import docker_lib, utils
 
 
 SECTION_MAP = {
@@ -11,12 +12,34 @@ SECTION_MAP = {
 }
 
 
+def pandoc_output(file_name):
+    try:
+        return pypandoc.convert_file(file_name, "jats")
+    except OSError:
+        # todo!! log exception pandoc is probably not installed locally
+        pass
+
+
+def docker_pandoc_output(file_name):
+    try:
+        return docker_lib.call_pandoc(file_name)
+    except ConnectionError:
+        # todo !! log exception - docker may not be running
+        pass
+
+
+def parse_file(file_name):
+    """issue the call to pandoc locally or via docker"""
+    output = pandoc_output(file_name)
+    if not output:
+        output = docker_pandoc_output(file_name)
+    return output
+
+
 def raw_jats(file_name, root_tag="root"):
     "convert file content to JATS"
-    jats_content = ""
-    output = pypandoc.convert_file(file_name, "jats")
-    jats_content = "<%s>%s</%s>" % (root_tag, output, root_tag)
-    return jats_content
+    output = parse_file(file_name)
+    return "<%s>%s</%s>" % (root_tag, output, root_tag)
 
 
 def clean_jats(file_name, root_tag="root"):

--- a/letterparser/utils.py
+++ b/letterparser/utils.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 "utility helper functions"
+import os
 import sys
 import re
 from elifetools import xmlio
@@ -99,3 +100,13 @@ def append_to_parent_tag(parent, tag_name, original_string,
         tag_name, tag_converted_string, namespaces, attributes_text)
     xmlio.append_minidom_xml_to_elementtree_xml(
         parent, minidom_tag, attributes=attributes, child_attributes=True)
+
+
+def get_file_name_path(file_name):
+    """return the folder path to a file excluding the file name itself"""
+    return os.sep.join(file_name.split(os.sep)[0:-1])
+
+
+def get_file_name_file(file_name):
+    """return the file name only removing the folder path preceeding it"""
+    return file_name.split(os.sep)[-1]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest==2.9.1
 ddt==1.1.0
 git+https://github.com/elifesciences/elife-tools.git@5b57b1798788cc1c56077601df9a66e8de6a0239#egg=elifetools
 git+https://github.com/elifesciences/elife-article.git@a4a3e5921a3458b0e281eb5fcd730100ce690747#egg=elifearticle
+docker==4.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,6 @@ pytest==2.9.1
 ddt==1.1.0
 git+https://github.com/elifesciences/elife-tools.git@5b57b1798788cc1c56077601df9a66e8de6a0239#egg=elifetools
 git+https://github.com/elifesciences/elife-article.git@a4a3e5921a3458b0e281eb5fcd730100ce690747#egg=elifearticle
+requests==2.22.0
 docker==4.0.2
+mock==1.3.0

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(name='letterparser',
         "elifearticle",
         "elifetools",
         "pypandoc",
+        "requests",
         "docker"
     ],
     url='https://github.com/elifesciences/decision-letter-parser',

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(name='letterparser',
         "elifearticle",
         "elifetools",
         "pypandoc",
+        "docker"
     ],
     url='https://github.com/elifesciences/decision-letter-parser',
     maintainer='eLife Sciences Publications Ltd.',

--- a/tests/test_docker_lib.py
+++ b/tests/test_docker_lib.py
@@ -1,0 +1,27 @@
+import unittest
+from mock import patch
+from letterparser import docker_lib
+
+
+class FakeContainerCollection:
+    def __init__(self, output):
+        self.output = output
+
+    def run(self, *args, **kwargs):
+        return self.output
+
+
+class FakeClient:
+    def __init__(self, output):
+        self.containers = FakeContainerCollection(output)
+
+
+class TestDockerLib(unittest.TestCase):
+
+    @patch.object(docker_lib, 'get_docker_client')
+    def test_call_pandoc(self, fake_get_docker_client):
+        """simple test for coverage"""
+        output = b'something'
+        expected = output.decode('utf8')
+        fake_get_docker_client.return_value = FakeClient(output)
+        self.assertEqual(docker_lib.call_pandoc('file_name'), expected)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,5 +1,8 @@
 import unittest
-from letterparser import parse
+from mock import patch
+import requests
+import pypandoc
+from letterparser import docker_lib, parse
 from tests import data_path, read_fixture
 
 
@@ -7,6 +10,25 @@ class TestParse(unittest.TestCase):
 
     def setUp(self):
         pass
+
+    @patch.object(pypandoc, 'convert_file')
+    def test_pandoc_output_exception(self, fake_convert_file):
+        fake_convert_file.side_effect = OSError()
+        self.assertRaises(OSError, parse.pandoc_output('file_name'))
+
+    @patch.object(docker_lib, 'call_pandoc')
+    def test_docker_pandoc_output_exception(self, fake_call_pandoc):
+        fake_call_pandoc.side_effect = requests.exceptions.ConnectionError()
+        self.assertRaises(
+            requests.exceptions.ConnectionError, parse.docker_pandoc_output('file_name'))
+
+    @patch.object(parse, 'docker_pandoc_output')
+    @patch.object(parse, 'pandoc_output')
+    def test_parse_file_no_pandoc(self, fake_pandoc_output, fake_docker_pandoc_output):
+        fake_pandoc_output.return_value = None
+        fake_docker_pandoc_output.return_value = None
+        output = parse.parse_file('file_name')
+        self.assertIsNone(output)
 
     def test_raw_jats(self):
         file_name = data_path('Dutzler 39122 edit.docx')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -162,3 +162,17 @@ class TestCleanPortion(unittest.TestCase):
                 value=new_string,
                 expected=test_data.get("expected"),
                 comment=test_data.get("comment")))
+
+
+class TestFileNameFunctions(unittest.TestCase):
+
+    def setUp(self):
+        self.file_name = 'folder/file.txt'
+
+    def test_get_file_name_path(self):
+        expected = 'folder'
+        self.assertEqual(utils.get_file_name_path(self.file_name), expected)
+
+    def test_get_file_name_file(self):
+        expected = 'file.txt'
+        self.assertEqual(utils.get_file_name_file(self.file_name), expected)


### PR DESCRIPTION
This library is a work-in-progress right now, so in order to compensate for when the `pandoc` executable is not available, fallback to calling pandoc from a Docker container.

The basics of this I tried in the unmerged https://github.com/elifesciences/decision-letter-parser/tree/pandoc-docker.

I have `pandoc` locally, which is not slowing me down, but eLife ci tests cannot run `pandoc` natively at this time.