### PR TITLE
More break tag conversion cases, code changes.

### DIFF
--- a/letterparser/parse.py
+++ b/letterparser/parse.py
@@ -72,7 +72,7 @@ def convert_break_tags(jats_content, root_tag="root"):
     break_sections = sections(jats_content, root_tag, break_section_map)
     # hanging tags could possibly be still open across <break /><break /> dividers
     hanging_tags = ["italic", "bold"]
-    open_tags = []
+    open_tags = set()
     for i, break_section in enumerate(break_sections):
         content = break_section.get("content")
         content = content.replace(break_section_match, "")
@@ -80,16 +80,29 @@ def convert_break_tags(jats_content, root_tag="root"):
             converted_jats_content += "<p>"
             for tag_name in open_tags:
                 converted_jats_content += utils.open_tag(tag_name)
-            open_tags = []
+
         converted_jats_content += content
+
         if i < len(break_sections)-1:
             # detect and close any open tags
             for tag_name in hanging_tags:
                 open_tag_count = content.count(utils.open_tag(tag_name))
                 close_tag_count = content.count(utils.close_tag(tag_name))
+                first_close_tag_index = content.find(utils.close_tag(tag_name))
+                first_open_tag_index = content.find(utils.open_tag(tag_name))
                 if open_tag_count > close_tag_count:
                     converted_jats_content += utils.close_tag(tag_name)
-                    open_tags.append(tag_name)
+                    open_tags.add(tag_name)
+                elif (first_close_tag_index and first_open_tag_index and
+                      first_close_tag_index < first_open_tag_index):
+                    # do the same if tag counts equal but close tag comes before the open tag
+                    converted_jats_content += utils.close_tag(tag_name)
+                    open_tags.add(tag_name)
+                elif tag_name in open_tags:
+                    # there are open tags from previous section
+                    converted_jats_content += utils.close_tag(tag_name)
+                    open_tags.add(tag_name)
+
             converted_jats_content += "</p>"
 
     # remove other break tags

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -70,3 +70,23 @@ class TestConvertBreakTags(unittest.TestCase):
         expected = '<p><italic>One</italic> <italic>two.</italic></p><p><italic>3.</italic></p>'
         result = parse.convert_break_tags(jats_content)
         self.assertEqual(result, expected)
+
+    def test_convert_break_tags_even_tag_count(self):
+        jats_content = (
+            '<p><italic>One.<break /><break />A </italic><italic>half. ' +
+            '<break /><break />Two.</italic></p>')
+        expected = (
+            '<p><italic>One.</italic></p><p><italic>A </italic><italic>half.</italic></p>' +
+            '<p><italic>Two.</italic></p>')
+        result = parse.convert_break_tags(jats_content)
+        self.assertEqual(result, expected)
+
+    def test_convert_break_tags_running_italic(self):
+        jats_content = (
+            '<p><italic>One.<break /><break />Keeps.<break /><break />' +
+            'Going.</italic></p>')
+        expected = (
+            '<p><italic>One.</italic></p><p><italic>Keeps.</italic></p>' +
+            '<p><italic>Going.</italic></p>')
+        result = parse.convert_break_tags(jats_content)
+        self.assertEqual(result, expected)


### PR DESCRIPTION
I planned to continue and improve the parsing and formatting of lists taken from `.docx` files. I tested converting a sample file I have, `Zaaijer 27798.docx`, which has some lists I was targetting, and it failed to build due to an XML parsing error.

I tracked down the cause to be more complicated situations where the break tag conversion function left open `<italic>` tags without a close tag in the new paragraphs. There are two types, added as test cases here.

The first is where the count of open and close tags is equal, causing the function to not open and close tags effectively.

The second, also from this same `.docx` file, is where a paragraph has an open `<italic>` tag, but then multiple `<break /><break />` tags before it closes it with the `</italic>` tag.

I also changed the tracking of open tags from a list to a `set()` to avoid duplication of tags.

This code is passing the test cases collected so far. The code isn't pretty, but it is green, and I am going to merge this and continue building this library.