### PR TITLE
Tweaks to clean up italic and disp-quote

### DIFF
--- a/letterparser/build.py
+++ b/letterparser/build.py
@@ -100,15 +100,29 @@ def split_content_sections(section):
     section_xml = clean_math_alternatives(section_xml)
 
     for block_tag in section_xml.findall("./*"):
-        content_section = OrderedDict()
         if block_tag.tag in ["list", "p", "table", "disp-quote"]:
-            rough_string = ElementTree.tostring(block_tag, 'utf8').decode('utf8')
-            rough_string = rough_string.replace("<?xml version='1.0' encoding='utf8'?>", "")
-            rough_string = rough_string.lstrip("\n")
-            content_section["tag_name"] = block_tag.tag
-            content_section["content"] = rough_string
-        content_sections.append(content_section)
+            # add p tags from disp-quote blocks
+            if block_tag.tag == "disp-quote":
+                for p_tag in block_tag.findall("./p"):
+                    append_tag_to_sections(content_sections, p_tag)
+            else:
+                append_tag_to_sections(content_sections, block_tag)
     return content_sections
+
+
+def append_tag_to_sections(sections, tag):
+    content_section = OrderedDict()
+    rough_string = element_to_string(tag)
+    content_section["tag_name"] = tag.tag
+    content_section["content"] = rough_string
+    sections.append(content_section)
+
+
+def element_to_string(tag):
+    rough_string = ElementTree.tostring(tag, 'utf8').decode('utf8')
+    rough_string = rough_string.replace("<?xml version='1.0' encoding='utf8'?>", "")
+    rough_string = rough_string.lstrip("\n")
+    return rough_string
 
 
 def clean_math_alternatives(section_xml):

--- a/letterparser/parse.py
+++ b/letterparser/parse.py
@@ -66,6 +66,8 @@ def best_jats(file_name, root_tag="root"):
 def convert_break_tags(jats_content, root_tag="root"):
     """convert break tags to p tags and remove unwanted break tags"""
     converted_jats_content = ""
+    # simple fix for italic sandwich
+    jats_content = jats_content.replace("<break /><italic><break />", "</p><p><italic>")
     # collapse double break tags into paragraph tags
     break_section_match = "<break /><break />"
     break_section_map = {"": break_section_match}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -23,7 +23,8 @@ class TestBuildArticles(unittest.TestCase):
         sections = {
             "content": (
                 '<p>One<xref xlink:href="" /></p>' +
-                '<list><list-item><p>Extra</p></list-item></list><p>Two</p>')
+                '<list><list-item><p>Extra</p></list-item></list><p>Two</p>' +
+                '<disp-quote><p>Quotation 1</p><p>Quotation 2</p></disp-quote>')
             }
         expected = [
             OrderedDict([
@@ -40,6 +41,14 @@ class TestBuildArticles(unittest.TestCase):
             OrderedDict([
                 ("tag_name", "p"),
                 ("content", '<p>Two</p>')
+            ]),
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", '<p>Quotation 1</p>')
+            ]),
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", '<p>Quotation 2</p>')
             ]),
         ]
         result = build.split_content_sections(sections)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -90,3 +90,9 @@ class TestConvertBreakTags(unittest.TestCase):
             '<p><italic>Going.</italic></p>')
         result = parse.convert_break_tags(jats_content)
         self.assertEqual(result, expected)
+
+    def test_convert_break_tags_italic_sandwich(self):
+        jats_content = '<p>Bread.<break /><italic><break />Cheese.</italic></p>'
+        expected = '<p>Bread.</p><p><italic>Cheese.</italic></p>'
+        result = parse.convert_break_tags(jats_content)
+        self.assertEqual(result, expected)


### PR DESCRIPTION
Testing locally with `Zaaijer 27798.docx` file, these are some improvements after comparing the output line by line, looking for any data omitted, or anything strange. Not too much, just a couple things here: replace italic break tags, and use the content inside `<disp-quote>` tags, because `<disp-quote>` later will have a new significance.