### PR TITLE
Library config file

### DIFF
--- a/letterparser.cfg
+++ b/letterparser.cfg
@@ -5,4 +5,4 @@ docker_image: knsit/pandoc:v2.5
 
 [elife]
 doi_pattern: 10.7554/eLife.{manuscript}.{id}
-preamble: <p>In the interests of transparency, eLife includes the editorial decision letter and accompanying author responses. A lightly edited version of the letter sent to the authors after peer review is shown, indicating the most substantive concerns; minor comments are not usually included.</p>
+preamble: <p>In the interests of transparency, eLife publishes the most substantive revision requests and the accompanying author responses.</p>

--- a/letterparser.cfg
+++ b/letterparser.cfg
@@ -1,5 +1,7 @@
 [DEFAULT]
+doi_pattern:
 preamble: 
 
 [elife]
+doi_pattern: 10.7554/eLife.{manuscript}.{id}
 preamble: <p>In the interests of transparency, eLife includes the editorial decision letter and accompanying author responses. A lightly edited version of the letter sent to the authors after peer review is shown, indicating the most substantive concerns; minor comments are not usually included.</p>

--- a/letterparser.cfg
+++ b/letterparser.cfg
@@ -1,6 +1,7 @@
 [DEFAULT]
 doi_pattern:
 preamble: 
+docker_image: knsit/pandoc:v2.5
 
 [elife]
 doi_pattern: 10.7554/eLife.{manuscript}.{id}

--- a/letterparser.cfg
+++ b/letterparser.cfg
@@ -1,0 +1,5 @@
+[DEFAULT]
+preamble: 
+
+[elife]
+preamble: <p>In the interests of transparency, eLife includes the editorial decision letter and accompanying author responses. A lightly edited version of the letter sent to the authors after peer review is shown, indicating the most substantive concerns; minor comments are not usually included.</p>

--- a/letterparser/conf.py
+++ b/letterparser/conf.py
@@ -1,0 +1,54 @@
+import configparser as configparser
+import json
+
+CONFIG_FILE = 'letterparser.cfg'
+BOOLEAN_VALUES = []
+INT_VALUES = []
+LIST_VALUES = []
+
+
+def load_config(config_file=CONFIG_FILE):
+    config = configparser.ConfigParser(interpolation=None)
+    config.read(config_file)
+    return config
+
+
+def raw_config(config_section, config_file=CONFIG_FILE):
+    "try to load the config section"
+    config = load_config(config_file)
+    if config.has_section(config_section):
+        return config[config_section]
+    # default
+    return config.defaults()
+
+
+def boolean_config(raw_config, value_name):
+    "extract the value as a boolean"
+    return raw_config.getboolean(value_name)
+
+
+def int_config(raw_config, value_name):
+    "extract the value as an int"
+    return raw_config.getint(value_name)
+
+
+def list_config(raw_config, value_name):
+    "extract the value as a list parsed from JSON"
+    return json.loads(raw_config.get(value_name))
+
+
+def parse_raw_config(raw_config):
+    "parse the raw config to something good"
+    config_dict = {}
+
+    for value_name in raw_config:
+        if value_name in BOOLEAN_VALUES:
+            config_dict[value_name] = boolean_config(raw_config, value_name)
+        elif value_name in INT_VALUES:
+            config_dict[value_name] = int_config(raw_config, value_name)
+        elif value_name in LIST_VALUES:
+            config_dict[value_name] = list_config(raw_config, value_name)
+        else:
+            # default
+            config_dict[value_name] = raw_config.get(value_name)
+    return config_dict

--- a/letterparser/docker_lib.py
+++ b/letterparser/docker_lib.py
@@ -3,9 +3,6 @@ import docker
 from letterparser import utils
 
 
-DOCKER_IMAGE = "knsit/pandoc:v2.5"
-
-
 def get_docker_client():
     return docker.from_env()
 
@@ -14,11 +11,11 @@ def create_docker_volumes_dict(source_path, bind_path='/data', mode='ro'):
     return {source_path: {'bind': bind_path, 'mode': mode}}
 
 
-def call_pandoc(file_name, output_format="jats"):
+def call_pandoc(file_name, docker_image, output_format="jats"):
     client = get_docker_client()
     file_name_path = utils.get_file_name_path(os.path.abspath(file_name))
     file_name_file = utils.get_file_name_file(file_name)
     volumes = create_docker_volumes_dict(file_name_path)
     command = 'pandoc "/data/%s" -t %s' % (file_name_file, output_format)
-    output = client.containers.run(DOCKER_IMAGE, command, volumes=volumes)
+    output = client.containers.run(docker_image, command, volumes=volumes)
     return output.decode('utf8')

--- a/letterparser/generate.py
+++ b/letterparser/generate.py
@@ -16,17 +16,17 @@ def set_if_value(element, name, value):
         element.set(name, value)
 
 
-def generate_xml_from_docx(file_name, root_tag="root", pretty=False, indent=""):
+def generate_xml_from_docx(file_name, root_tag="root", pretty=False, indent="", config=None):
     """generate JATS output from docx file_name"""
-    articles = docx_to_articles(file_name, root_tag)
+    articles = docx_to_articles(file_name, root_tag, config)
     jats_xml = generate(articles)
     return output_xml(jats_xml, pretty, indent)
 
 
-def docx_to_articles(file_name, root_tag="root"):
+def docx_to_articles(file_name, root_tag="root", config=None):
     """convert the docx file to Article objects"""
     jats_content = parse.best_jats(file_name, root_tag)
-    return build.build_articles(jats_content)
+    return build.build_articles(jats_content, config)
 
 
 def generate(articles, root_tag="root"):

--- a/letterparser/generate.py
+++ b/letterparser/generate.py
@@ -25,7 +25,7 @@ def generate_xml_from_docx(file_name, root_tag="root", pretty=False, indent="", 
 
 def docx_to_articles(file_name, root_tag="root", config=None):
     """convert the docx file to Article objects"""
-    jats_content = parse.best_jats(file_name, root_tag)
+    jats_content = parse.best_jats(file_name, root_tag, config=config)
     return build.build_articles(jats_content, file_name=file_name, config=config)
 
 

--- a/letterparser/generate.py
+++ b/letterparser/generate.py
@@ -26,7 +26,7 @@ def generate_xml_from_docx(file_name, root_tag="root", pretty=False, indent="", 
 def docx_to_articles(file_name, root_tag="root", config=None):
     """convert the docx file to Article objects"""
     jats_content = parse.best_jats(file_name, root_tag)
-    return build.build_articles(jats_content, config)
+    return build.build_articles(jats_content, file_name=file_name, config=config)
 
 
 def generate(articles, root_tag="root"):

--- a/letterparser/parse.py
+++ b/letterparser/parse.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 import pypandoc
 import requests
 from letterparser import docker_lib, utils
+from letterparser.conf import raw_config, parse_raw_config
 
 
 SECTION_MAP = {
@@ -10,6 +11,13 @@ SECTION_MAP = {
     "decision_letter": "<p><bold>Decision letter</bold></p>",
     "author_response": "<p><bold>Author response</bold></p>"
 }
+
+
+def ensure_config(config):
+    """populate a default config if it is not specified"""
+    if not config:
+        config = parse_raw_config(raw_config(None))
+    return config
 
 
 def pandoc_output(file_name):
@@ -38,18 +46,20 @@ def parse_file(file_name, config=None):
     """issue the call to pandoc locally or via docker"""
     output = pandoc_output(file_name)
     if not output:
-        output = docker_pandoc_output(file_name, config=config)
+        output = docker_pandoc_output(file_name, config)
     return output
 
 
 def raw_jats(file_name, root_tag="root", config=None):
     "convert file content to JATS"
+    config = ensure_config(config)
     output = parse_file(file_name, config=config)
     return "<%s>%s</%s>" % (root_tag, output, root_tag)
 
 
 def clean_jats(file_name, root_tag="root", config=None):
     """cleaner rough JATS output from the raw_jats"""
+    config = ensure_config(config)
     jats_content = ""
     raw_jats_content = raw_jats(file_name, root_tag, config=config)
     jats_content = utils.collapse_newlines(raw_jats_content)
@@ -59,6 +69,7 @@ def clean_jats(file_name, root_tag="root", config=None):
 
 def best_jats(file_name, root_tag="root", config=None):
     """from file input, produce the best JATS output possible"""
+    config = ensure_config(config)
     clean_jats_content = clean_jats(file_name, root_tag, config=config)
     clean_jats_content = utils.remove_strike(clean_jats_content)
     jats_content = convert_break_tags(clean_jats_content, root_tag)

--- a/letterparser/utils.py
+++ b/letterparser/utils.py
@@ -128,3 +128,12 @@ def open_tag(tag_name):
 
 def close_tag(tag_name):
     return "</%s>" % tag_name
+
+
+def manuscript_from_file_name(file_name):
+    # todo!!!
+    # may requiring changing when final file name format is decided
+    # based on file name e.g. Dutzler 39122 edit.docx
+    if file_name:
+        return get_file_name_file(file_name).split('.')[0].split(' ')[1]
+    return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ git+https://github.com/elifesciences/elife-article.git@a4a3e5921a3458b0e281eb5fc
 requests==2.22.0
 docker==4.0.2
 mock==1.3.0
+configparser==3.5.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setup(name='letterparser',
         "elifetools",
         "pypandoc",
         "requests",
-        "docker"
+        "docker",
+        "configparser"
     ],
     url='https://github.com/elifesciences/decision-letter-parser',
     maintainer='eLife Sciences Publications Ltd.',

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from xml.etree import ElementTree
 from letterparser import build, parse
 from letterparser.generate import output_xml
+from letterparser.conf import raw_config, parse_raw_config
 from tests import data_path
 
 
@@ -14,10 +15,25 @@ class TestBuildArticles(unittest.TestCase):
         """simple test for coverage of parsing sections"""
         file_name = data_path('sections.docx')
         jats_content = parse.best_jats(file_name)
-        articles = build.build_articles(jats_content)
+        config = parse_raw_config(raw_config('elife'))
+        articles = build.build_articles(jats_content, config)
         self.assertEqual(len(articles), 2)
         self.assertEqual(articles[0].article_type, "decision-letter")
         self.assertEqual(articles[1].article_type, "reply")
+
+    def test_build_articles_default_preamble(self):
+        """build article with a default preamble"""
+        jats_content = '<p><bold>Decision letter</bold></p><p>Test</p>'
+        config = parse_raw_config(raw_config('elife'))
+        articles = build.build_articles(jats_content, config)
+        self.assertEqual(len(articles), 1)
+        self.assertEqual(articles[0].article_type, "decision-letter")
+        self.assertEqual(articles[0].content_blocks[0].block_type, "boxed-text")
+        self.assertEqual(
+            articles[0].content_blocks[0].content[0:35],
+            "<p>In the interests of transparency")
+        self.assertEqual(articles[0].content_blocks[1].block_type, "p")
+        self.assertEqual(articles[0].content_blocks[1].content, "Test")
 
     def test_split_content_sections(self):
         sections = {

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -11,21 +11,29 @@ from tests import data_path
 
 class TestBuildArticles(unittest.TestCase):
 
+    def setUp(self):
+        self.config = parse_raw_config(raw_config('elife'))
+
     def test_build_articles(self):
         """simple test for coverage of parsing sections"""
         file_name = data_path('sections.docx')
-        jats_content = parse.best_jats(file_name)
-        config = parse_raw_config(raw_config('elife'))
-        articles = build.build_articles(jats_content, config)
+        jats_content = parse.best_jats(file_name, config=self.config)
+        articles = build.build_articles(jats_content, config=self.config)
         self.assertEqual(len(articles), 2)
         self.assertEqual(articles[0].article_type, "decision-letter")
         self.assertEqual(articles[1].article_type, "reply")
 
+    def test_build_articles_no_config(self):
+        """simple test for coverage of parsing with no config specified"""
+        file_name = data_path('sections.docx')
+        jats_content = parse.best_jats(file_name, config=None)
+        articles = build.build_articles(jats_content, config=None)
+        self.assertEqual(len(articles), 2)
+
     def test_build_articles_default_preamble(self):
         """build article with a default preamble"""
         jats_content = '<p><bold>Decision letter</bold></p><p>Test</p>'
-        config = parse_raw_config(raw_config('elife'))
-        articles = build.build_articles(jats_content, config=config)
+        articles = build.build_articles(jats_content, config=self.config)
         self.assertEqual(len(articles), 1)
         self.assertEqual(articles[0].article_type, "decision-letter")
         self.assertEqual(articles[0].content_blocks[0].block_type, "boxed-text")
@@ -220,26 +228,33 @@ class TestBuildArticles(unittest.TestCase):
         self.assertEqual(result[2].content, '<disp-formula></disp-formula>')
 
 
+class TestDefaultPreamble(unittest.TestCase):
+
+    def test_default_preamble_no_config(self):
+        """default preamble if no config specified"""
+        self.assertIsNone(build.default_preamble(None))
+
+
 class TestBuildDoi(unittest.TestCase):
+
+    def setUp(self):
+        self.config = parse_raw_config(raw_config('elife'))
 
     def test_build_doi(self):
         file_name = 'folder/Dutzler 39122 edit.docx'
         id_value = 'sa1'
-        config = parse_raw_config(raw_config('elife'))
         expected = '10.7554/eLife.39122.sa1'
-        doi = build.build_doi(file_name, id_value, config)
+        doi = build.build_doi(file_name, id_value, self.config)
         self.assertEqual(doi, expected)
 
     def test_build_doi_no_file_name(self):
         file_name = None
         id_value = 'sa1'
-        config = parse_raw_config(raw_config('elife'))
-        doi = build.build_doi(file_name, id_value, config)
+        doi = build.build_doi(file_name, id_value, self.config)
         self.assertIsNone(doi)
 
     def test_build_doi_no_config(self):
         file_name = 'folder/Dutzler 39122 edit.docx'
         id_value = 'sa1'
-        config = None
-        doi = build.build_doi(file_name, id_value, config)
+        doi = build.build_doi(file_name, id_value, None)
         self.assertIsNone(doi)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -25,7 +25,7 @@ class TestBuildArticles(unittest.TestCase):
         """build article with a default preamble"""
         jats_content = '<p><bold>Decision letter</bold></p><p>Test</p>'
         config = parse_raw_config(raw_config('elife'))
-        articles = build.build_articles(jats_content, config)
+        articles = build.build_articles(jats_content, config=config)
         self.assertEqual(len(articles), 1)
         self.assertEqual(articles[0].article_type, "decision-letter")
         self.assertEqual(articles[0].content_blocks[0].block_type, "boxed-text")
@@ -218,3 +218,28 @@ class TestBuildArticles(unittest.TestCase):
         self.assertEqual(result[1].content, '<list-item></list-item>')
         self.assertEqual(result[2].block_type, "p")
         self.assertEqual(result[2].content, '<disp-formula></disp-formula>')
+
+
+class TestBuildDoi(unittest.TestCase):
+
+    def test_build_doi(self):
+        file_name = 'folder/Dutzler 39122 edit.docx'
+        id_value = 'sa1'
+        config = parse_raw_config(raw_config('elife'))
+        expected = '10.7554/eLife.39122.sa1'
+        doi = build.build_doi(file_name, id_value, config)
+        self.assertEqual(doi, expected)
+
+    def test_build_doi_no_file_name(self):
+        file_name = None
+        id_value = 'sa1'
+        config = parse_raw_config(raw_config('elife'))
+        doi = build.build_doi(file_name, id_value, config)
+        self.assertIsNone(doi)
+
+    def test_build_doi_no_config(self):
+        file_name = 'folder/Dutzler 39122 edit.docx'
+        id_value = 'sa1'
+        config = None
+        doi = build.build_doi(file_name, id_value, config)
+        self.assertIsNone(doi)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,0 +1,83 @@
+# coding=utf-8
+
+import unittest
+import configparser as configparser
+from letterparser import conf
+
+
+def build_raw_config_for_testing(value_name, value):
+    "build a config object with one value and return the defaults for testing"
+    config = configparser.ConfigParser(interpolation=None)
+    config['DEFAULT'][value_name] = value
+    raw_config = config['DEFAULT']
+    return raw_config
+
+
+class TestConf(unittest.TestCase):
+
+    def setUp(self):
+        # some values for testing
+        self.boolean_value = u'True'
+        self.boolean_expected = True
+        self.int_value = u'42'
+        self.int_expected = 42
+        self.list_value = u'[1,1,2,3,5]'
+        self.list_expected = [1, 1, 2, 3, 5]
+
+    def test_load_config(self):
+        "check building default configuration"
+        config = conf.load_config()
+        self.assertIsNotNone(config)
+        self.assertGreater(len(config.sections()), 0)
+
+    def test_raw_config_none(self):
+        "check reading raw config default when the config section is None"
+        config = conf.raw_config(None)
+        self.assertGreater(len(config), 0)
+
+    def test_boolean_config(self):
+        "test parsing a boolean value"
+        value = self.boolean_value
+        value_name = u'test'
+        expected = self.boolean_expected
+        raw_config = build_raw_config_for_testing(value_name, value)
+        self.assertEqual(conf.boolean_config(raw_config, value_name), expected)
+
+    def test_int_config(self):
+        "test parsing an int value"
+        value = self.int_value
+        value_name = u'test'
+        expected = self.int_expected
+        raw_config = build_raw_config_for_testing(value_name, value)
+        self.assertEqual(conf.int_config(raw_config, value_name), expected)
+
+    def test_list_config(self):
+        "test parsing a list value"
+        value = self.list_value
+        value_name = u'test'
+        expected = self.list_expected
+        raw_config = build_raw_config_for_testing(value_name, value)
+        self.assertEqual(conf.list_config(raw_config, value_name), expected)
+
+    def test_parse_raw_config(self):
+        "test parsing a raw config of all the different value types"
+        # override the library values
+        conf.BOOLEAN_VALUES = [u'test_boolean']
+        conf.INT_VALUES = [u'test_int']
+        conf.LIST_VALUES = [u'test_list']
+        # build a config object
+        config = configparser.ConfigParser(interpolation=None)
+        config['DEFAULT'][u'test_boolean'] = self.boolean_value
+        config['DEFAULT'][u'test_int'] = self.int_value
+        config['DEFAULT'][u'test_list'] = self.list_value
+        # parse the raw config for coverage
+        config_dict = conf.parse_raw_config(config['DEFAULT'])
+        # assert some things
+        self.assertIsNotNone(config_dict)
+        self.assertEqual(config_dict.get('test_boolean'), self.boolean_expected)
+        self.assertEqual(config_dict.get('test_int'), self.int_expected)
+        self.assertEqual(config_dict.get('test_list'), self.list_expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_docker_lib.py
+++ b/tests/test_docker_lib.py
@@ -23,5 +23,6 @@ class TestDockerLib(unittest.TestCase):
         """simple test for coverage"""
         output = b'something'
         expected = output.decode('utf8')
+        docker_image = 'example/image_name_for_test_case'
         fake_get_docker_client.return_value = FakeClient(output)
-        self.assertEqual(docker_lib.call_pandoc('file_name'), expected)
+        self.assertEqual(docker_lib.call_pandoc('file_name', docker_image), expected)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -4,6 +4,7 @@ import unittest
 from xml.etree.ElementTree import Element
 from letterparser import generate
 from letterparser.objects import ContentBlock
+from letterparser.conf import raw_config, parse_raw_config
 from tests import data_path, helpers, read_fixture
 
 
@@ -53,7 +54,9 @@ class TestGenerateFromDocx(unittest.TestCase):
     def test_generate_xml_from_docx(self):
         """simple test for code coverage"""
         file_name = data_path('Dutzler 39122 edit.docx')
-        pretty_xml = generate.generate_xml_from_docx(file_name, pretty=True, indent="    ")
+        config = parse_raw_config(raw_config('elife'))
+        pretty_xml = generate.generate_xml_from_docx(
+            file_name, pretty=True, indent="    ", config=config)
         self.assertIsNotNone(pretty_xml)
 
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -17,10 +17,17 @@ class TestParse(unittest.TestCase):
         self.assertRaises(OSError, parse.pandoc_output('file_name'))
 
     @patch.object(docker_lib, 'call_pandoc')
+    def test_docker_pandoc_output_with_config(self, fake_call_pandoc):
+        config = {"docker_image": "image_name"}
+        fake_call_pandoc.side_effect = requests.exceptions.ConnectionError()
+        self.assertRaises(
+            requests.exceptions.ConnectionError, parse.docker_pandoc_output('file_name', config))
+
+    @patch.object(docker_lib, 'call_pandoc')
     def test_docker_pandoc_output_exception(self, fake_call_pandoc):
         fake_call_pandoc.side_effect = requests.exceptions.ConnectionError()
         self.assertRaises(
-            requests.exceptions.ConnectionError, parse.docker_pandoc_output('file_name'))
+            requests.exceptions.ConnectionError, parse.docker_pandoc_output('file_name', None))
 
     @patch.object(parse, 'docker_pandoc_output')
     @patch.object(parse, 'pandoc_output')

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -3,13 +3,14 @@ from mock import patch
 import requests
 import pypandoc
 from letterparser import docker_lib, parse
+from letterparser.conf import raw_config, parse_raw_config
 from tests import data_path, read_fixture
 
 
 class TestParse(unittest.TestCase):
 
     def setUp(self):
-        pass
+        self.config = parse_raw_config(raw_config('elife'))
 
     @patch.object(pypandoc, 'convert_file')
     def test_pandoc_output_exception(self, fake_convert_file):
@@ -40,26 +41,26 @@ class TestParse(unittest.TestCase):
     def test_raw_jats(self):
         file_name = data_path('Dutzler 39122 edit.docx')
         expected = read_fixture('raw_jats_dutzler_39122.xml')
-        jats_content = parse.raw_jats(file_name)
+        jats_content = parse.raw_jats(file_name, config=self.config)
         self.assertEqual(jats_content, expected)
 
     def test_clean_jats(self):
         file_name = data_path('Dutzler 39122 edit.docx')
         expected = read_fixture('clean_jats_dutzler_39122.xml')
-        jats_content = parse.clean_jats(file_name)
+        jats_content = parse.clean_jats(file_name, config=self.config)
         parse.sections(jats_content)
         self.assertEqual(jats_content, expected)
 
     def test_best_jats(self):
         file_name = data_path('Dutzler 39122 edit.docx')
         expected = read_fixture('best_jats_dutzler_39122.xml')
-        jats_content = parse.best_jats(file_name)
+        jats_content = parse.best_jats(file_name, config=self.config)
         self.assertEqual(jats_content, expected)
 
     def test_sections(self):
         file_name = data_path('Dutzler 39122 edit.docx')
         expected = read_fixture('dutzler_39122_sections.py')
-        jats_content = parse.best_jats(file_name)
+        jats_content = parse.best_jats(file_name, config=self.config)
         sections = parse.sections(jats_content)
         self.assertEqual(sections, expected)
 

--- a/tests/test_parse_list.py
+++ b/tests/test_parse_list.py
@@ -1,27 +1,28 @@
 import unittest
 from letterparser import parse
+from letterparser.conf import raw_config, parse_raw_config
 from tests import data_path, read_fixture
 
 
 class TestParseList(unittest.TestCase):
 
     def setUp(self):
-        pass
+        self.config = parse_raw_config(raw_config('elife'))
 
     def test_raw_jats_27798(self):
         file_name = data_path('list-27798.docx')
         expected = read_fixture('list-27798_raw.xml')
-        jats_content = parse.raw_jats(file_name)
+        jats_content = parse.raw_jats(file_name, config=self.config)
         self.assertEqual(jats_content, expected)
 
     def test_raw_jats_25776(self):
         file_name = data_path('list-25776.docx')
         expected = read_fixture('list-25776_raw.xml')
-        jats_content = parse.raw_jats(file_name)
+        jats_content = parse.raw_jats(file_name, config=self.config)
         self.assertEqual(jats_content, expected)
 
     def test_raw_jats_list_types(self):
         file_name = data_path('list-types.docx')
         expected = read_fixture('list-types.xml')
-        jats_content = parse.raw_jats(file_name)
+        jats_content = parse.raw_jats(file_name, config=self.config)
         self.assertEqual(jats_content, expected)

--- a/tests/test_parse_sections.py
+++ b/tests/test_parse_sections.py
@@ -1,16 +1,17 @@
 import unittest
 from letterparser import parse
+from letterparser.conf import raw_config, parse_raw_config
 from tests import data_path, read_fixture
 
 
 class TestParseSections(unittest.TestCase):
 
     def setUp(self):
-        pass
+        self.config = parse_raw_config(raw_config('elife'))
 
     def test_sections(self):
         file_name = data_path('sections.docx')
         expected = read_fixture('sections_sections.py')
-        jats_content = parse.best_jats(file_name)
+        jats_content = parse.best_jats(file_name, config=self.config)
         sections = parse.sections(jats_content)
         self.assertEqual(sections, expected)

--- a/tests/test_parse_strike_through.py
+++ b/tests/test_parse_strike_through.py
@@ -1,21 +1,22 @@
 import unittest
 from letterparser import parse
+from letterparser.conf import raw_config, parse_raw_config
 from tests import data_path, read_fixture
 
 
 class TestStrikeThrough(unittest.TestCase):
 
     def setUp(self):
-        pass
+        self.config = parse_raw_config(raw_config('elife'))
 
     def test_raw_jats(self):
         file_name = data_path('strike-through-34497.docx')
         expected = read_fixture('strike-through-34497_raw.xml')
-        jats_content = parse.raw_jats(file_name)
+        jats_content = parse.raw_jats(file_name, config=self.config)
         self.assertEqual(jats_content, expected)
 
     def test_best_jats(self):
         file_name = data_path('strike-through-34497.docx')
         expected = read_fixture('strike-through-34497_best.xml')
-        jats_content = parse.best_jats(file_name)
+        jats_content = parse.best_jats(file_name, config=self.config)
         self.assertEqual(jats_content, expected)

--- a/tests/test_parse_table.py
+++ b/tests/test_parse_table.py
@@ -1,27 +1,28 @@
 import unittest
 from letterparser import parse
+from letterparser.conf import raw_config, parse_raw_config
 from tests import data_path, read_fixture
 
 
 class TestParseTable(unittest.TestCase):
 
     def setUp(self):
-        pass
+        self.config = parse_raw_config(raw_config('elife'))
 
     def test_raw_jats_35684(self):
         file_name = data_path('table-35684.docx')
         expected = read_fixture('table-35684_raw.xml')
-        jats_content = parse.raw_jats(file_name)
+        jats_content = parse.raw_jats(file_name, config=self.config)
         self.assertEqual(jats_content, expected)
 
     def test_raw_jats_43333(self):
         file_name = data_path('table-43333.docx')
         expected = read_fixture('table-43333_raw.xml')
-        jats_content = parse.raw_jats(file_name)
+        jats_content = parse.raw_jats(file_name, config=self.config)
         self.assertEqual(jats_content, expected)
 
     def test_raw_jats_42299(self):
         file_name = data_path('table-42299.docx')
         expected = read_fixture('table-42299_raw.xml')
-        jats_content = parse.raw_jats(file_name)
+        jats_content = parse.raw_jats(file_name, config=self.config)
         self.assertEqual(jats_content, expected)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -176,3 +176,25 @@ class TestFileNameFunctions(unittest.TestCase):
     def test_get_file_name_file(self):
         expected = 'file.txt'
         self.assertEqual(utils.get_file_name_file(self.file_name), expected)
+
+
+@ddt
+class TestManuscriptFromFileName(unittest.TestCase):
+
+    @data(
+        {
+            "file_name": None,
+            "expected": None
+        },
+        {
+            "file_name": "Dutzler 39122 edit.docx",
+            "expected": "39122"
+        },
+        {
+            "file_name": "folder/Dutzler 39122 edit.docx",
+            "expected": "39122"
+        },
+        )
+    def test_manuscript_from_file_name(self, test_data):
+        manuscript = utils.manuscript_from_file_name(test_data.get("file_name"))
+        self.assertEqual(manuscript, test_data.get("expected"))


### PR DESCRIPTION
Fixes https://github.com/elifesciences/decision-letter-parser/issues/34
Fixes https://github.com/elifesciences/decision-letter-parser/issues/29

Related to the config ticket https://github.com/elifesciences/decision-letter-parser/issues/43

This introduces a `letterparser.cfg` config file to hold some configuration details, a `conf.py` module to parse those values, and pass the config around to functions that use it.

How the five-digit manuscript number for eLife is parsed from file names will change soon when a `.zip` file convention is added in the coming days.

