### PR TITLE
Switch to official pandoc Docker image.

### DIFF
--- a/letterparser.cfg
+++ b/letterparser.cfg
@@ -1,7 +1,7 @@
 [DEFAULT]
 doi_pattern:
 preamble: 
-docker_image: knsit/pandoc:v2.5
+docker_image: pandoc/core:2.6
 fig_filename_pattern: journalname-{manuscript:0>5}-{id_value}-fig{num}
 video_filename_pattern: journalname-{manuscript:0>5}-{id_value}-video{num}
 

--- a/letterparser/docker_lib.py
+++ b/letterparser/docker_lib.py
@@ -16,6 +16,6 @@ def call_pandoc(file_name, docker_image, output_format="jats"):
     file_name_path = utils.get_file_name_path(os.path.abspath(file_name))
     file_name_file = utils.get_file_name_file(file_name)
     volumes = create_docker_volumes_dict(file_name_path)
-    command = 'pandoc "/data/%s" -t %s' % (file_name_file, output_format)
+    command = '--to=%s "%s"' % (output_format, file_name_file)
     output = client.containers.run(docker_image, command, volumes=volumes)
     return output.decode('utf8')


### PR DESCRIPTION
Small changes to use the official pandoc Docker image. The existing tests pass for me when using the pandoc version 2.6 image. If all green, I will switch over to this for going forward, because the image size is smaller on disk.