### PR TITLE
Tweaks and fixes from creating kitchen sink XML

### DIFF
--- a/letterparser.cfg
+++ b/letterparser.cfg
@@ -6,7 +6,7 @@ fig_filename_pattern: journalname-{manuscript:0>5}-{id_value}-fig{num}
 video_filename_pattern: journalname-{manuscript:0>5}-{id_value}-video{num}
 
 [elife]
-doi_pattern: 10.7554/eLife.{manuscript}.{id}
+doi_pattern: 10.7554/eLife.{manuscript:0>5}.{id}
 preamble: <p>In the interests of transparency, eLife publishes the most substantive revision requests and the accompanying author responses.</p>
 fig_filename_pattern: elife-{manuscript:0>5}-{id_value}-fig{num}
 video_filename_pattern: elife-{manuscript:0>5}-{id_value}-video{num}

--- a/letterparser/build.py
+++ b/letterparser/build.py
@@ -46,7 +46,8 @@ def build_articles(jats_content, file_name=None, config=None):
         doi = build_doi(file_name, id_value, config)
 
         if section.get("section_type") == "decision_letter":
-            article = build_decision_letter(section, config, preamble_section, id_value, manuscript)
+            article = build_decision_letter(
+                section, config, preamble_section, id_value, doi, manuscript)
         else:
             article = build_sub_article(section, config, "reply", id_value, doi, manuscript)
         articles.append(article)

--- a/letterparser/build.py
+++ b/letterparser/build.py
@@ -222,7 +222,8 @@ def fig_element(label, title, content):
     utils.append_to_parent_tag(caption_tag, 'title', title, utils.XML_NAMESPACE_MAP)
 
     # append content as a p tag in the caption
-    utils.append_to_parent_tag(caption_tag, 'p', content, utils.XML_NAMESPACE_MAP)
+    if content:
+        utils.append_to_parent_tag(caption_tag, 'p', content, utils.XML_NAMESPACE_MAP)
 
     graphic_tag = SubElement(fig_tag, 'graphic')
     graphic_tag.set('mimetype', 'image')

--- a/letterparser/build.py
+++ b/letterparser/build.py
@@ -209,11 +209,11 @@ def build_fig(content):
         content_match = re.match(title_label_match, title_parts[0])
         fig_content['title'] = content_match.group(1).lstrip()
     else:
-    fig_content['title'] = title_parts[0].lstrip() + '.'
-    # strip the title / legend close tag
-    content_remainder = '.'.join(title_parts[1:])
+        fig_content['title'] = title_parts[0].lstrip() + '.'
+        # strip the title / legend close tag
+        content_remainder = '.'.join(title_parts[1:])
         content_match = re.match(title_label_match, content_remainder)
-    fig_content['content'] = content_match.group(1).lstrip()
+        fig_content['content'] = content_match.group(1).lstrip()
     return fig_content
 
 

--- a/letterparser/build.py
+++ b/letterparser/build.py
@@ -204,10 +204,15 @@ def build_fig(content):
     fig_content['label'] = parts_match.group(1)
     remainder = parts_match.group(2)
     title_parts = remainder.split('.')
+    title_label_match = r'(.*)\&lt;.*\&gt;$'
+    if len(title_parts) <= 1:
+        content_match = re.match(title_label_match, title_parts[0])
+        fig_content['title'] = content_match.group(1).lstrip()
+    else:
     fig_content['title'] = title_parts[0].lstrip() + '.'
     # strip the title / legend close tag
     content_remainder = '.'.join(title_parts[1:])
-    content_match = re.match(r'(.*)\&lt;.*\&gt;$', content_remainder)
+        content_match = re.match(title_label_match, content_remainder)
     fig_content['content'] = content_match.group(1).lstrip()
     return fig_content
 

--- a/letterparser/build.py
+++ b/letterparser/build.py
@@ -204,8 +204,8 @@ def build_fig(content):
     fig_content['label'] = parts_match.group(1)
     remainder = parts_match.group(2)
     title_parts = remainder.split('.')
-    title_label_match = r'(.*)\&lt;.*\&gt;$'
-    if len(title_parts) <= 1:
+    title_label_match = r'^(.*)\&lt;.*\&gt;$'
+    if len(title_parts) == 1:
         content_match = re.match(title_label_match, title_parts[0])
         fig_content['title'] = content_match.group(1).lstrip()
     else:
@@ -250,12 +250,14 @@ def media_element(label, title, content, mimetype="video"):
     label_tag = SubElement(media_tag, 'label')
     label_tag.text = label
 
-    caption_tag = SubElement(media_tag, 'caption')
-    utils.append_to_parent_tag(caption_tag, 'title', title, utils.XML_NAMESPACE_MAP)
+    if title or content:
+        caption_tag = SubElement(media_tag, 'caption')
+        if title:
+            utils.append_to_parent_tag(caption_tag, 'title', title, utils.XML_NAMESPACE_MAP)
 
-    # append content as a p tag in the caption
-    if content:
-        utils.append_to_parent_tag(caption_tag, 'p', content, utils.XML_NAMESPACE_MAP)
+        # append content as a p tag in the caption
+        if content:
+            utils.append_to_parent_tag(caption_tag, 'p', content, utils.XML_NAMESPACE_MAP)
 
     return media_tag
 

--- a/letterparser/build.py
+++ b/letterparser/build.py
@@ -309,9 +309,10 @@ def process_content_sections(content_sections):
                 prev_content = None
                 appended_content = ''
         elif action == "add":
-            if prev_action == "append":
+            if prev_action == "append" and appended_content:
                 content_blocks.append(ContentBlock(prev_tag_name, appended_content, prev_attr))
-            content_blocks.append(ContentBlock(tag_name, content, attr))
+            if content:
+                content_blocks.append(ContentBlock(tag_name, content, attr))
             prev_content = None
             appended_content = ''
         elif action == "append":
@@ -376,9 +377,11 @@ def process_p_content(content, prev_content, wrap=None):
         if match_fig_content_start(content):
             wrap = 'fig'
             content = ''
+            action = "add"
         elif match_video_content_start(content):
             wrap = 'media'
             content = ''
+            action = "add"
 
     if wrap:
         if match_fig_content_title_end(content) or match_video_content_title_end(content):

--- a/letterparser/utils.py
+++ b/letterparser/utils.py
@@ -136,5 +136,15 @@ def manuscript_from_file_name(file_name):
     # may requiring changing when final file name format is decided
     # based on file name e.g. Dutzler 39122 edit.docx
     if file_name:
-        return get_file_name_file(file_name).split('.')[0].split(' ')[1]
+        first_file_name_part = get_file_name_file(file_name).split('.')[0]
+        spaced_parts = first_file_name_part.split(' ')
+        hyphenated_parts = first_file_name_part.split('-')
+        if len(spaced_parts) > 1:
+            manuscript_string = spaced_parts[1]
+        else:
+            manuscript_string = hyphenated_parts[1]
+        try:
+            return str(int(manuscript_string))
+        except ValueError:
+            return None
     return None

--- a/tests/fixtures/kitchen_sink.xml
+++ b/tests/fixtures/kitchen_sink.xml
@@ -2,14 +2,14 @@
 <root xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
     <sub-article article-type="decision-letter" id="sa1">
         <front-stub>
-            <article-id pub-id-type="doi">10.7554/eLife.00666.DL</article-id>
+            <article-id pub-id-type="doi">10.7554/eLife.00666.sa1</article-id>
             <title-group>
                 <article-title>Decision letter</article-title>
             </title-group>
         </front-stub>
         <body>
             <boxed-text>
-                <p>In the interests of transparency, eLife includes the editorial decision letter and accompanying author responses. A lightly edited version of the letter sent to the authors after peer review is shown, indicating the most substantive concerns; minor comments are not usually included.</p>
+                <p>In the interests of transparency, eLife publishes the most substantive revision requests and the accompanying author responses.</p>
             </boxed-text>
             <p>
                 Thank you for submitting your article &quot;The eLife research article&quot; for consideration by 
@@ -29,7 +29,7 @@
     </sub-article>
     <sub-article article-type="reply" id="sa2">
         <front-stub>
-            <article-id pub-id-type="doi">10.7554/eLife.00666.AR</article-id>
+            <article-id pub-id-type="doi">10.7554/eLife.00666.sa2</article-id>
             <title-group>
                 <article-title>Author response</article-title>
             </title-group>

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -144,13 +144,13 @@ class TestBuildArticles(unittest.TestCase):
         content_sections = [
             OrderedDict([
                 ("tag_name", "list"),
-                ("content", '<list></list>'),
+                ("content", '<list><list-item><p>Item</p></list-item></list>'),
             ])
         ]
         result = build.process_content_sections(content_sections)
         self.assertEqual(result[0].block_type, "list")
         self.assertEqual(result[0].attr, {})
-        self.assertEqual(result[0].content, '')
+        self.assertEqual(result[0].content, '<list-item><p>Item</p></list-item>')
 
     def test_process_content_sections_disp_quote(self):
         content_sections = [
@@ -381,7 +381,7 @@ class TestProcessP(unittest.TestCase):
 
     def test_process_p_author_image_start(self):
         content = '&lt;Author response image 1&gt;'
-        expected = ('', 'p', None, 'append', 'fig')
+        expected = ('', 'p', None, 'add', 'fig')
         self.assertEqual(build.process_p_content(content, None), expected)
 
     def test_process_p_author_image_end(self):
@@ -393,7 +393,7 @@ class TestProcessP(unittest.TestCase):
 
     def test_process_p_decision_image_start(self):
         content = '&lt;Decision letter image 2&gt;'
-        expected = ('', 'p', None, 'append', 'fig')
+        expected = ('', 'p', None, 'add', 'fig')
         self.assertEqual(build.process_p_content(content, None), expected)
 
     def test_process_p_decision_image_end(self):
@@ -405,7 +405,7 @@ class TestProcessP(unittest.TestCase):
 
     def test_process_p_author_video_start(self):
         content = '&lt;Author response video 1&gt;'
-        expected = ('', 'p', None, 'append', 'media')
+        expected = ('', 'p', None, 'add', 'media')
         self.assertEqual(build.process_p_content(content, None), expected)
 
     def test_process_p_author_video_end(self):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -279,6 +279,20 @@ class TestBuildFig(unittest.TestCase):
         fig_content = build.build_fig(content)
         self.assertEqual(fig_content, expected)
 
+    def test_build_fig_simple_title(self):
+        """example of a title with no full stop"""
+        content = (
+            '&lt;Author response image 1 title/legend&gt;'
+            '<bold>Label</bold>Title'
+            '&lt;/Author response image 1 title/legend&gt;'
+            )
+        expected = OrderedDict([
+            ('label', 'Label'),
+            ('title', 'Title')
+        ])
+        fig_content = build.build_fig(content)
+        self.assertEqual(fig_content, expected)
+
 
 class TestBuildVideo(unittest.TestCase):
 

--- a/tests/test_generate_kitchen_sink.py
+++ b/tests/test_generate_kitchen_sink.py
@@ -8,14 +8,12 @@ from tests import helpers, read_fixture
 
 def kitchen_sink_decision_letter():
     sub_article = helpers.base_decision_letter()
-    sub_article.doi = "10.7554/eLife.00666.DL"
+    sub_article.doi = "10.7554/eLife.00666.sa1"
 
     preamble_block = ContentBlock("boxed-text")
     preamble_block.content_blocks.append(ContentBlock("p", (
-        "In the interests of transparency, eLife includes the editorial decision letter" +
-        " and accompanying author responses. A lightly edited version of the letter sent" +
-        " to the authors after peer review is shown, indicating the most substantive concerns;" +
-        " minor comments are not usually included.")))
+        "In the interests of transparency, eLife publishes the most substantive revision" +
+        " requests and the accompanying author responses.")))
     sub_article.content_blocks.append(preamble_block)
 
     sub_article.content_blocks.append(ContentBlock("p", (
@@ -43,7 +41,7 @@ def kitchen_sink_decision_letter():
 
 def kitchen_sink_author_response():
     sub_article = helpers.base_author_response()
-    sub_article.doi = "10.7554/eLife.00666.AR"
+    sub_article.doi = "10.7554/eLife.00666.sa2"
 
     disp_quote_block = ContentBlock("disp-quote")
     disp_quote_block.attr["content-type"] = "editor-comment"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -194,6 +194,14 @@ class TestManuscriptFromFileName(unittest.TestCase):
             "file_name": "folder/Dutzler 39122 edit.docx",
             "expected": "39122"
         },
+        {
+            "file_name": "folder/elife-00666.docx",
+            "expected": "666"
+        },
+        {
+            "file_name": "folder/elife-NaN.docx",
+            "expected": None
+        },
         )
     def test_manuscript_from_file_name(self, test_data):
         manuscript = utils.manuscript_from_file_name(test_data.get("file_name"))


### PR DESCRIPTION
These are some accumulated changes from attempting to generate XML output like the kitchen sink XML file from a composed `.docx` file. The `.docx` file is not finished yet -- almost.

I do not want to lose these fixes and I may switch over to the parsing of a few remaining content pieces before I finish the `.docx` file. Since disp-quote tags and table parsing are not done yet, it is not possible generate the full kitchen sink XML yet without more code.

I think existing test cases are largely unchanged here. These changes are based on parsing real `.docx` files and seeing what breaks and what is missing or wrong.