### PR TITLE
disp-quote editor comment

### DIFF
--- a/letterparser/build.py
+++ b/letterparser/build.py
@@ -333,7 +333,7 @@ def process_content_sections(content_sections):
                 prev_content = content
                 appended_content = content
         elif action == "add":
-            if prev_action == "append":
+            if prev_action == "append" and appended_content:
                 content_blocks.append(ContentBlock(prev_tag_name, appended_content, prev_attr))
                 appended_content = ''
             if content and not wrap:

--- a/letterparser/build.py
+++ b/letterparser/build.py
@@ -300,41 +300,11 @@ def process_content_section(section, content_blocks, appended_content, prev):
     """profile and format the section content adding content blocks"""
     tag_name = section.get("tag_name")
     content, tag_name, attr, action, wrap = process_content(tag_name, section.get("content"), prev)
+
     if prev.get('wrap') and not wrap:
-        # finish the fig tag content
-        if prev.get('wrap') == 'fig':
-            # format the content into the figure content block
-            appended_content = appended_content + content
-            fig_content = build_fig(appended_content)
-            fig_tag = fig_element(
-                fig_content.get('label'),
-                fig_content.get('title'),
-                fig_content.get('content'))
-            content_block_content = fig_element_to_string(fig_tag)
-            content_blocks.append(ContentBlock("fig", content_block_content, prev.get('attr')))
-            prev['content'] = None
-            appended_content = ''
-        elif prev.get('wrap') == 'media':
-            # format the content into the video media content block
-            appended_content = appended_content + content
-            video_content = build_fig(appended_content)
-            media_tag = media_element(
-                video_content.get('label'),
-                video_content.get('title'),
-                video_content.get('content'))
-            content_block_content = media_element_to_string(media_tag)
-            content_blocks.append(
-                ContentBlock("media", content_block_content, media_tag.attrib))
-            prev['content'] = None
-            appended_content = ''
-        elif prev.get('wrap') == 'disp-quote':
-            disp_quote_tag = disp_quote_element(appended_content)
-            content_block_content = disp_quote_element_to_string(disp_quote_tag)
-            tag_attr = {'content-type': 'editor-comment'}
-            content_blocks.append(
-                ContentBlock("disp-quote", content_block_content, tag_attr))
-            prev['content'] = content
-            appended_content = content
+        content_blocks, appended_content, prev = finish_wrap(
+            content_blocks, content, appended_content, prev)
+
     elif action == "add":
         if prev.get('action') == "append" and appended_content:
             content_blocks.append(
@@ -356,6 +326,46 @@ def process_content_section(section, content_blocks, appended_content, prev):
     prev['tag_name'] = tag_name
     prev['attr'] = attr
     prev['wrap'] = wrap
+
+    return content_blocks, appended_content, prev
+
+
+def finish_wrap(content_blocks, content, appended_content, prev):
+    """add appended content to a wrap"""
+    # finish the fig tag content
+    if prev.get('wrap') == 'fig':
+        # format the content into the figure content block
+        appended_content = appended_content + content
+        fig_content = build_fig(appended_content)
+        fig_tag = fig_element(
+            fig_content.get('label'),
+            fig_content.get('title'),
+            fig_content.get('content'))
+        content_block_content = fig_element_to_string(fig_tag)
+        content_blocks.append(ContentBlock("fig", content_block_content, prev.get('attr')))
+        prev['content'] = None
+        appended_content = ''
+    elif prev.get('wrap') == 'media':
+        # format the content into the video media content block
+        appended_content = appended_content + content
+        video_content = build_fig(appended_content)
+        media_tag = media_element(
+            video_content.get('label'),
+            video_content.get('title'),
+            video_content.get('content'))
+        content_block_content = media_element_to_string(media_tag)
+        content_blocks.append(
+            ContentBlock("media", content_block_content, media_tag.attrib))
+        prev['content'] = None
+        appended_content = ''
+    elif prev.get('wrap') == 'disp-quote':
+        disp_quote_tag = disp_quote_element(appended_content)
+        content_block_content = disp_quote_element_to_string(disp_quote_tag)
+        tag_attr = {'content-type': 'editor-comment'}
+        content_blocks.append(
+            ContentBlock("disp-quote", content_block_content, tag_attr))
+        prev['content'] = content
+        appended_content = content
 
     return content_blocks, appended_content, prev
 

--- a/letterparser/build.py
+++ b/letterparser/build.py
@@ -262,9 +262,24 @@ def media_element(label, title, content, mimetype="video"):
     return media_tag
 
 
+def disp_quote_element(content):
+    """wrap non-italicised content into disp-quote tag"""
+    root_tag = Element('disp-quote')
+
+    if content:
+        utils.append_to_parent_tag(root_tag, 'disp-quote', content, utils.XML_NAMESPACE_MAP)
+
+    return root_tag[0]
+
+
 def media_element_to_string(tag):
     rough_string = element_to_string(tag)
     return utils.clean_portion(rough_string, "media")
+
+
+def disp_quote_element_to_string(tag):
+    rough_string = element_to_string(tag)
+    return utils.clean_portion(rough_string, "disp-quote")
 
 
 def process_content_sections(content_sections):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -238,6 +238,36 @@ class TestBuildArticles(unittest.TestCase):
         self.assertEqual(result[2].block_type, "p")
         self.assertEqual(result[2].content, '<disp-formula></disp-formula>')
 
+    def test_process_content_sections_p_italic(self):
+        """test case for italic p"""
+        content_sections = [
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", '<p>Regular paragraph.</p>'),
+            ]),
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", '<p><italic>First quoted paragraph.</italic></p>'),
+            ]),
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", '<p><italic>Second quoted paragraph.</italic></p>'),
+            ]),
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", '<p>Response paragraph.</p>'),
+            ]),
+        ]
+        result = build.process_content_sections(content_sections)
+        self.assertEqual(result[0].block_type, 'p')
+        self.assertEqual(result[0].content, 'Regular paragraph.')
+        self.assertEqual(result[1].block_type, 'disp-quote')
+        self.assertEqual(result[1].attr.get('content-type'), 'editor-comment')
+        self.assertEqual(
+            result[1].content, '<p>First quoted paragraph.</p><p>Second quoted paragraph.</p>')
+        self.assertEqual(result[2].block_type, 'p')
+        self.assertEqual(result[2].content, 'Response paragraph.')
+
 
 class TestDefaultPreamble(unittest.TestCase):
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -304,6 +304,16 @@ class TestBuildVideo(unittest.TestCase):
         self.assertEqual(video_content, expected)
 
 
+class TestBuildDispQuote(unittest.TestCase):
+
+    def test_disp_quote_element(self):
+        content = '<p>One.</p><p>Two.</p>'
+        expected = b'<disp-quote><p>One.</p><p>Two.</p></disp-quote>'
+        tag_content = build.disp_quote_element(content)
+        tag_xml = ElementTree.tostring(tag_content)
+        self.assertEqual(tag_xml, expected)
+
+
 class TestBuildSubArticle(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -404,53 +404,57 @@ class TestProcessP(unittest.TestCase):
 
     def test_p_basic(self):
         content = '<p>Basic.</p>'
+        prev = {}
         expected = ('Basic.', 'p', None, 'append', None)
-        self.assertEqual(build.process_p_content(content, None), expected)
+        self.assertEqual(build.process_p_content(content, prev), expected)
 
     def test_p_add_previous(self):
         content = '<p>Basic.</p>'
-        prev_content = 'Previous.'
+        prev = {'content': 'Previous.'}
         expected = ('Basic.', 'p', None, 'add', None)
-        self.assertEqual(build.process_p_content(content, prev_content), expected)
+        self.assertEqual(build.process_p_content(content, prev), expected)
 
     def test_p_append_disp_formula(self):
         content = '<p><disp-formula></disp-formula></p>'
-        prev_content = '<disp-formula></disp-formula>'
+        prev = {'content': '<disp-formula></disp-formula>'}
         expected = ('<disp-formula></disp-formula>', 'p', None, 'append', None)
-        self.assertEqual(build.process_p_content(content, prev_content), expected)
+        self.assertEqual(build.process_p_content(content, prev), expected)
 
     def test_process_p_author_image_start(self):
         content = '&lt;Author response image 1&gt;'
+        prev = {}
         expected = ('', 'p', None, 'add', 'fig')
-        self.assertEqual(build.process_p_content(content, None), expected)
+        self.assertEqual(build.process_p_content(content, prev), expected)
 
     def test_process_p_author_image_end(self):
         content = 'blah blah&lt;/Author response image 1 title/legend&gt;'
-        wrap = 'fig'
+        prev = {'wrap': 'fig'}
         expected = ('blah blah&lt;/Author response image 1 title/legend&gt;',
                     'p', None, 'add', None)
-        self.assertEqual(build.process_p_content(content, None, wrap), expected)
+        self.assertEqual(build.process_p_content(content, prev), expected)
 
     def test_process_p_decision_image_start(self):
         content = '&lt;Decision letter image 2&gt;'
+        prev = {}
         expected = ('', 'p', None, 'add', 'fig')
-        self.assertEqual(build.process_p_content(content, None), expected)
+        self.assertEqual(build.process_p_content(content, prev), expected)
 
     def test_process_p_decision_image_end(self):
         content = 'blah blah&lt;/Decision letter image 2 title/legend&gt;'
-        wrap = 'fig'
+        prev = {'wrap': 'fig'}
         expected = ('blah blah&lt;/Decision letter image 2 title/legend&gt;',
                     'p', None, 'add', None)
-        self.assertEqual(build.process_p_content(content, None, wrap), expected)
+        self.assertEqual(build.process_p_content(content, prev), expected)
 
     def test_process_p_author_video_start(self):
         content = '&lt;Author response video 1&gt;'
+        prev = {}
         expected = ('', 'p', None, 'add', 'media')
-        self.assertEqual(build.process_p_content(content, None), expected)
+        self.assertEqual(build.process_p_content(content, prev), expected)
 
     def test_process_p_author_video_end(self):
         content = 'blah blah&lt;/Author response video 1 title/legend&gt;'
-        wrap = 'fig'
+        prev = {'wrap': 'fig'}
         expected = ('blah blah&lt;/Author response video 1 title/legend&gt;',
                     'p', None, 'add', None)
-        self.assertEqual(build.process_p_content(content, None, wrap), expected)
+        self.assertEqual(build.process_p_content(content, prev), expected)


### PR DESCRIPTION
For eLife article samples, a paragraph that is entirely italic in the author reponse corresponds with a `<disp-quote content-type="editor-comment">` XML element in the output. This PR makes that happen.

It further expanded using the `wrap` logic, making it more complicated and confusing, so this also includes refactoring of the code into separate functions. As well, tracking previous content uses a standard dict of values for clarity and reducing the number of arguments.