### PR TITLE
xref tag wrapping logic

### DIFF
--- a/letterparser/generate.py
+++ b/letterparser/generate.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 
+from collections import OrderedDict
 from xml.dom import minidom
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element, SubElement
@@ -113,6 +114,26 @@ def set_content_blocks(parent, content_blocks, level=1):
         if block_tag is not None and block.content_blocks:
             # recursion
             set_content_blocks(block_tag, block.content_blocks, level+1)
+
+
+def labels(root):
+    """find label values from assets"""
+    asset_labels = []
+    name_type_map = OrderedDict([
+        ('fig', 'fig'),
+        ('media', 'video'),
+        ('table-wrap', 'table')
+    ])
+    for tag_name in list(name_type_map):
+        for block_tag in root.findall(".//" + tag_name):
+            label_tags = block_tag.findall(".//label")
+            if block_tag.get("id") and label_tags:
+                asset_label = OrderedDict()
+                asset_label["id"] = block_tag.get("id")
+                asset_label["type"] = name_type_map.get(tag_name)
+                asset_label["text"] = label_tags[0].text
+                asset_labels.append(asset_label)
+    return asset_labels
 
 
 def output_xml(root, pretty=False, indent=""):

--- a/letterparser/utils.py
+++ b/letterparser/utils.py
@@ -123,8 +123,13 @@ def get_file_name_file(file_name):
     return file_name.split(os.sep)[-1]
 
 
-def open_tag(tag_name):
-    return "<%s>" % tag_name
+def open_tag(tag_name, attr=None):
+    if not attr:
+        return "<%s>" % tag_name
+    attr_values = []
+    for name, value in sorted(attr.items()):
+        attr_values.append('%s="%s"' % (name, value))
+    return "<%s %s>" % (tag_name, ' '.join(attr_values))
 
 
 def close_tag(tag_name):

--- a/tests/fixtures/kitchen_sink.xml
+++ b/tests/fixtures/kitchen_sink.xml
@@ -56,7 +56,7 @@
                 <graphic mimetype="image" xlink:href="elife-00666-sa2-fig1.jpg"/>
             </fig>
             <table-wrap id="sa2table1">
-                <label>Author response Table 1.</label>
+                <label>Author response table 1.</label>
                 <caption>
                     <p>Author response table</p>
                 </caption>

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 
 import unittest
+from collections import OrderedDict
+from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
 from elifearticle.article import ContentBlock
 from letterparser import generate
@@ -58,6 +60,58 @@ class TestGenerateFromDocx(unittest.TestCase):
         pretty_xml = generate.generate_xml_from_docx(
             file_name, pretty=True, indent="    ", config=config)
         self.assertIsNotNone(pretty_xml)
+
+
+class TestLabels(unittest.TestCase):
+
+    def test_labels_kitchen_sink(self):
+        xml_string = read_fixture('kitchen_sink.xml')
+        expected = [
+            OrderedDict([
+                ('id', 'sa1fig1'),
+                ('type', 'fig'),
+                ('text', 'Decision letter image 1.')
+            ]),
+            OrderedDict([
+                ('id', 'sa2fig1'),
+                ('type', 'fig'),
+                ('text', 'Author response image 1.')
+            ]),
+            OrderedDict([
+                ('id', 'sa2video1'),
+                ('type', 'video'),
+                ('text', 'Author response video 1.')
+            ]),
+            OrderedDict([
+                ('id', 'sa2table1'),
+                ('type', 'table'),
+                ('text', 'Author response table 1.')
+            ])
+        ]
+        article_xml = ElementTree.fromstring(xml_string)
+        asset_labels = generate.labels(article_xml)
+        self.assertEqual(asset_labels, expected)
+
+    def test_labels_39122(self):
+        file_name = data_path('Dutzler 39122 edit.docx')
+        expected = [
+            OrderedDict([
+                ('id', 'sa2fig1'),
+                ('type', 'fig'),
+                ('text', 'Author response image 1.')
+            ]),
+            OrderedDict([
+                ('id', 'sa2fig2'),
+                ('type', 'fig'),
+                ('text', 'Author response image 2.')
+            ])
+        ]
+        config = parse_raw_config(raw_config('elife'))
+        pretty_xml = generate.generate_xml_from_docx(
+            file_name, pretty=True, indent="    ", config=config)
+        article_xml = ElementTree.fromstring(pretty_xml)
+        asset_labels = generate.labels(article_xml)
+        self.assertEqual(asset_labels, expected)
 
 
 class TestGenerateMaxLevel(unittest.TestCase):

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -114,6 +114,29 @@ class TestLabels(unittest.TestCase):
         self.assertEqual(asset_labels, expected)
 
 
+class TestAssetXrefTags(unittest.TestCase):
+
+    def test_asset_xref_tags(self):
+        xml_string = (
+            '<body>'
+            '<p>First paragraph.</p>'
+            '<p>An Author response video 1.</p>'
+            '<media id="sa2video1"><label>Author response video 1</label></media>'
+            '</body>'
+        )
+        expected = (
+            b'<body>'
+            b'<p>First paragraph.</p>'
+            b'<p>An <xref ref-type="video" rid="sa2video1">Author response video 1</xref>.</p>'
+            b'<media id="sa2video1"><label>Author response video 1</label></media>'
+            b'</body>'
+        )
+        article_xml = ElementTree.fromstring(xml_string)
+        generate.asset_xref_tags(article_xml)
+        article_xml_string = ElementTree.tostring(article_xml)
+        self.assertEqual(article_xml_string, expected)
+
+
 class TestGenerateMaxLevel(unittest.TestCase):
 
     def test_generate_max_level(self):

--- a/tests/test_generate_kitchen_sink.py
+++ b/tests/test_generate_kitchen_sink.py
@@ -68,7 +68,7 @@ def kitchen_sink_author_response():
         ' mimetype="image" xlink:href="elife-00666-sa2-fig1.jpg"/>')))
 
     sub_article.content_blocks.append(ContentBlock("table-wrap", (
-        "<label>Author response Table 1.</label><caption><p>Author response table</p></caption>" +
+        "<label>Author response table 1.</label><caption><p>Author response table</p></caption>" +
         '<table frame="hsides" rules="groups"><thead>' +
         '<tr><th>Sample</th><th>Same</th><th>Difference more than 10%</th></tr>' +
         '</thead><tbody>' +

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -206,3 +206,17 @@ class TestManuscriptFromFileName(unittest.TestCase):
     def test_manuscript_from_file_name(self, test_data):
         manuscript = utils.manuscript_from_file_name(test_data.get("file_name"))
         self.assertEqual(manuscript, test_data.get("expected"))
+
+
+class TestOpenTag(unittest.TestCase):
+
+    def test_open_tag(self):
+        tag_name = 'italic'
+        expected = '<italic>'
+        self.assertEqual(utils.open_tag(tag_name), expected)
+
+    def test_open_tag_with_attr(self):
+        tag_name = 'xref'
+        attr = {'id': 'sa2fig1', 'ref-type': 'fig'}
+        expected = '<xref id="sa2fig1" ref-type="fig">'
+        self.assertEqual(utils.open_tag(tag_name, attr), expected)


### PR DESCRIPTION
After some experimentation and a slight rework, this is an example of adding `<xref>` tags around mentions of assets in a paragraph. It seems to be stable enough across the tests and files I'm testing with so far.

The challenge came up because you cannot replace a tag in an`ElementTree`, but I didn't want to try using the standard XML editing route, that would require checking `text` and `tail`, and trying to edit existing tags. For this reason, I continued with the original plan of converting XML -> string, adding the `<xref>` tag with regular expressions, then parsing the string -> XML again. Once inserting the tag into the parent tag and removing the old tag was working, this seems ok for now.

I expanded `open_tag()` to optionally accept tag attributes.

The terms to match come from `<label>` values in a `<fig>`, `<media>` or `<table-wrap>`. These are detected separately, along with the type of asset and the `@id` attribute, to be used in creating the open tag.

A small change to the kitchen sink XML -- the `Table` in the label I lowercased to `table` for consistency with how the wrapping logic works.

This library is still in development and not relied upon heavily yet, and if tests are green, I will merge this PR myself.