### PR TITLE
Set Article.manuscript value in build_sub_article.

### DIFF
--- a/letterparser/build.py
+++ b/letterparser/build.py
@@ -80,6 +80,7 @@ def build_decision_letter(section, config, preamble_section=None, id_value=None,
 def build_sub_article(section, config, article_type=None, id_value=None, doi=None, manuscript=None):
     article = Article(doi)
     article.id = id_value
+    article.manuscript = manuscript
     if article_type:
         article.article_type = article_type
     # add the content

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -430,6 +430,7 @@ class TestBuildSubArticle(unittest.TestCase):
             section, self.config, article_type, id_value, doi, manuscript)
         self.assertEqual(article.doi, doi)
         self.assertEqual(article.id, id_value)
+        self.assertEqual(article.manuscript, manuscript)
         self.assertEqual(article.article_type, article_type)
         self.assertEqual(article.content_blocks[0].block_type, 'media')
         self.assertEqual(article.content_blocks[0].attr['xlink:href'], 'elife-00666-sa2-video1')


### PR DESCRIPTION
Found when integrating this into a real workflow, being able to get the `Article.manuscript` property will come in handy. When building the sub article object, set this property to the value that was passed in.