### PR TITLE
Fix block order when xref tags are added

### DIFF
--- a/letterparser/generate.py
+++ b/letterparser/generate.py
@@ -204,8 +204,10 @@ def asset_xref_tags(root):
     # look for tags that have a p tag in them
     for p_tag_parent in root.findall('.//p/..'):
         # loop through the p tags in this parent tag, keeping track of the p tag index
-        for tag_index, p_tag in enumerate(p_tag_parent.iter('p')):
-            tag_string = build.element_to_string(p_tag)
+        for tag_index, child_tag in enumerate(p_tag_parent.iterfind('*')):
+            if not child_tag.tag == 'p':
+                continue
+            tag_string = build.element_to_string(child_tag)
             modified = False
             for asset_label in asset_labels:
                 # look for the label in the text but not preceeded by a > char
@@ -224,7 +226,7 @@ def asset_xref_tags(root):
                 tag_string = re.sub(r'^<p>', p_tag_string, str(tag_string))
                 new_p_tag = ElementTree.fromstring(tag_string)
                 # remove old tag
-                p_tag_parent.remove(p_tag)
+                p_tag_parent.remove(child_tag)
                 # insert the new tag
                 p_tag_parent.insert(tag_index, new_p_tag)
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -4,60 +4,16 @@ import unittest
 from collections import OrderedDict
 from xml.etree import ElementTree
 from elifearticle.article import Article, ContentBlock
-from letterparser import build, parse
+from letterparser import build
 from letterparser.generate import output_xml
 from letterparser.conf import raw_config, parse_raw_config
-from tests import data_path, read_fixture
+from tests import read_fixture
 
 
-class TestBuildArticles(unittest.TestCase):
+class TestSplitContentSections(unittest.TestCase):
 
     def setUp(self):
         self.config = parse_raw_config(raw_config('elife'))
-
-    def test_build_articles(self):
-        """simple test for coverage of parsing sections"""
-        file_name = data_path('sections.docx')
-        jats_content = parse.best_jats(file_name, config=self.config)
-        articles = build.build_articles(jats_content, config=self.config)
-        self.assertEqual(len(articles), 2)
-        self.assertEqual(articles[0].article_type, "decision-letter")
-        self.assertEqual(articles[1].article_type, "reply")
-
-    def test_build_articles_no_config(self):
-        """simple test for coverage of parsing with no config specified"""
-        file_name = data_path('sections.docx')
-        jats_content = parse.best_jats(file_name, config=None)
-        articles = build.build_articles(jats_content, config=None)
-        self.assertEqual(len(articles), 2)
-
-    def test_build_articles_default_preamble(self):
-        """build article with a default preamble"""
-        jats_content = '<p><bold>Decision letter</bold></p><p>Test</p>'
-        articles = build.build_articles(jats_content, config=self.config)
-        self.assertEqual(len(articles), 1)
-        self.assertEqual(articles[0].article_type, "decision-letter")
-        self.assertEqual(articles[0].content_blocks[0].block_type, "boxed-text")
-        self.assertEqual(
-            articles[0].content_blocks[0].content[0:35],
-            "<p>In the interests of transparency")
-        self.assertEqual(articles[0].content_blocks[1].block_type, "p")
-        self.assertEqual(articles[0].content_blocks[1].content, "Test")
-
-    def test_build_articles_disp_quote_italic(self):
-        """buggy situation where two italic tags are in a disp-quote content p"""
-        jats_content = (
-            '<p><bold>Author response</bold></p><p><italic>A series of important changes is'
-            ' requested before the manuscript could be</italic> <italic>considered for'
-            ' publication in eLife.</italic></p><p><italic>1) The authors need to do'
-            ' .....</italic></p>')
-        articles = build.build_articles(jats_content, config=self.config)
-        self.assertEqual(len(articles), 1)
-        self.assertEqual(articles[0].article_type, "reply")
-        self.assertEqual(articles[0].content_blocks[0].block_type, "disp-quote")
-        self.assertEqual(
-            articles[0].content_blocks[0].content[0:52],
-            "<p>A series of important changes is requested before")
 
     def test_split_content_sections(self):
         sections = {
@@ -103,6 +59,9 @@ class TestBuildArticles(unittest.TestCase):
         expected = read_fixture('author_response_image_1_sections.py')
         sections = build.split_content_sections(section)
         self.assertEqual(sections, expected)
+
+
+class TestCleanMath(unittest.TestCase):
 
     def test_clean_math_alternatives(self):
         xml_string = (

--- a/tests/test_build_articles.py
+++ b/tests/test_build_articles.py
@@ -1,0 +1,78 @@
+# coding=utf-8
+
+import unittest
+from letterparser import build, parse
+from letterparser.conf import raw_config, parse_raw_config
+from tests import data_path
+
+
+class TestBuildArticles(unittest.TestCase):
+
+    def setUp(self):
+        self.config = parse_raw_config(raw_config('elife'))
+
+    def test_build_articles(self):
+        """simple test for coverage of parsing sections"""
+        file_name = data_path('sections.docx')
+        jats_content = parse.best_jats(file_name, config=self.config)
+        articles = build.build_articles(jats_content, config=self.config)
+        self.assertEqual(len(articles), 2)
+        self.assertEqual(articles[0].article_type, "decision-letter")
+        self.assertEqual(articles[1].article_type, "reply")
+
+    def test_build_articles_no_config(self):
+        """simple test for coverage of parsing with no config specified"""
+        file_name = data_path('sections.docx')
+        jats_content = parse.best_jats(file_name, config=None)
+        articles = build.build_articles(jats_content, config=None)
+        self.assertEqual(len(articles), 2)
+
+    def test_build_articles_default_preamble(self):
+        """build article with a default preamble"""
+        jats_content = '<p><bold>Decision letter</bold></p><p>Test</p>'
+        articles = build.build_articles(jats_content, config=self.config)
+        self.assertEqual(len(articles), 1)
+        self.assertEqual(articles[0].article_type, "decision-letter")
+        self.assertEqual(articles[0].content_blocks[0].block_type, "boxed-text")
+        self.assertEqual(
+            articles[0].content_blocks[0].content[0:35],
+            "<p>In the interests of transparency")
+        self.assertEqual(articles[0].content_blocks[1].block_type, "p")
+        self.assertEqual(articles[0].content_blocks[1].content, "Test")
+
+    def test_build_articles_fig(self):
+        """edge case with fig caption and block order"""
+        file_name = 'elife-00666.docx'
+        jats_content = (
+            '<p><bold>Author response</bold></p>'
+            '<p><italic>Editor comment one.</italic></p>'
+            '<p><italic>Editor comment two.</italic></p>'
+            '<p>First <italic>paragraph</italic>.</p>'
+            '<p>&lt;Author response image 1&gt;</p>'
+            '<p>&lt;Author response image 1 title/legend&gt;<bold>Author response image 1.</bold>'
+            'Title up to first full stop. Caption <sup>2+</sup> calculated using'
+            '&lt;/Author response image 1 title/legend&gt;</p>'
+            '<p><italic>Editor comment paragraph.</italic></p>'
+            '<p>Paragraph one.</p>'
+            '<p>Paragraph two.</p>')
+        articles = build.build_articles(jats_content, file_name=file_name, config=self.config)
+        self.assertEqual(len(articles), 1)
+        self.assertEqual(articles[0].article_type, "reply")
+        self.assertEqual(articles[0].content_blocks[0].block_type, "disp-quote")
+        self.assertEqual(articles[0].content_blocks[0].content, (
+            "<p>Editor comment one.</p><p>Editor comment two.</p>"))
+        self.assertEqual(articles[0].content_blocks[1].block_type, "p")
+        self.assertEqual(articles[0].content_blocks[1].content, (
+            "First <italic>paragraph</italic>."))
+        self.assertEqual(articles[0].content_blocks[2].block_type, "fig")
+        self.assertEqual(articles[0].content_blocks[2].content, (
+            '<label>Author response image 1.</label><caption>'
+            '<title>Title up to first full stop.</title>'
+            '<p>Caption <sup>2+</sup> calculated using</p></caption>'
+            '<graphic mimetype="image" xlink:href="elife-00666-sa1-fig1" />'))
+        self.assertEqual(articles[0].content_blocks[3].block_type, "disp-quote")
+        self.assertEqual(articles[0].content_blocks[3].content, "<p>Editor comment paragraph.</p>")
+        self.assertEqual(articles[0].content_blocks[4].block_type, "p")
+        self.assertEqual(articles[0].content_blocks[4].content, "Paragraph one.")
+        self.assertEqual(articles[0].content_blocks[5].block_type, "p")
+        self.assertEqual(articles[0].content_blocks[5].content, "Paragraph two.")

--- a/tests/test_build_content_sections.py
+++ b/tests/test_build_content_sections.py
@@ -243,6 +243,48 @@ class TestProcessContentSections(unittest.TestCase):
         self.assertEqual(result[2].block_type, 'p')
         self.assertEqual(result[2].content, 'Response paragraph.')
 
+    def test_process_content_sections_image(self):
+        content_sections = [
+            OrderedDict([
+                ("tag_name", "disp-quote"),
+                ("content", '<p>First editor comment.</p><p>An extra paragraph</p>'),
+            ]),
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", '<p>First <italic>paragraph</italic>.</p>'),
+            ]),
+            OrderedDict([
+                ('tag_name', 'p'),
+                ('content', '<p>&lt;Author response image 1&gt;</p>')
+            ]),
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", (
+                    '<p>&lt;Author response image 1 title/legend&gt;'
+                    '<bold>Author response image 1.</bold>'
+                    ' Title up to first full stop. Caption <sup>2+</sup> calculated using'
+                    '&lt;/Author response image 1 title/legend&gt;</p>')),
+            ]),
+            OrderedDict([
+                ("tag_name", "disp-quote"),
+                ("content", '<p>Editor comment paragraph.</p>'),
+            ]),
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", '<p>Paragraph.</p>'),
+            ]),
+        ]
+        result = build.process_content_sections(content_sections, prefs=self.prefs)
+        self.assertEqual(result[0].block_type, 'disp-quote')
+        self.assertEqual(result[1].block_type, 'p')
+        self.assertEqual(result[2].block_type, 'fig')
+        self.assertEqual(result[2].content, (
+            '<label>Author response image 1.</label>'
+            '<caption><title>Title up to first full stop.</title>'
+            '<p>Caption <sup>2+</sup> calculated using</p></caption>'
+            '<graphic mimetype="image" xlink:href="todo" />'))
+        self.assertEqual(result[3].block_type, 'disp-quote')
+
     def test_process_content_sections_image_no_title(self):
         content_sections = [
             OrderedDict([

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -183,6 +183,43 @@ class TestAssetXrefTags(unittest.TestCase):
         article_xml_string = ElementTree.tostring(article_xml)
         self.assertEqual(article_xml_string, expected)
 
+    def test_asset_xref_tags_fig(self):
+        """test fix highlight also where the paragraph is after the graphic tag"""
+        xml_string = (
+            '<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            '<p>First paragraph.</p>'
+            '<p>Another paragraph.</p>'
+            '<p>An Author response image 1.</p>'
+            '<fig id="sa2fig1"><label>Author response image 1.</label>'
+            '<graphic mimetype="image" xlink:href="elife-00002-sa2-fig1.jpg"/>'
+            '</fig>'
+            '<media id="sa2video1"><label>Author response video 1</label></media>'
+            '<p>2nd Author response image 1.</p>'
+            '<p>Next paragraph.</p>'
+            '<p>3rd Author response image 1.</p>'
+            '<p>4th Author response image 1.</p>'
+            '</body>'
+        )
+        expected = (
+            b'<body xmlns:xlink="http://www.w3.org/1999/xlink">'
+            b'<p>First paragraph.</p>'
+            b'<p>Another paragraph.</p>'
+            b'<p>An <xref ref-type="fig" rid="sa2fig1">Author response image 1.</xref></p>'
+            b'<fig id="sa2fig1"><label>Author response image 1.</label>'
+            b'<graphic mimetype="image" xlink:href="elife-00002-sa2-fig1.jpg" />'
+            b'</fig>'
+            b'<media id="sa2video1"><label>Author response video 1</label></media>'
+            b'<p>2nd <xref ref-type="fig" rid="sa2fig1">Author response image 1.</xref></p>'
+            b'<p>Next paragraph.</p>'
+            b'<p>3rd <xref ref-type="fig" rid="sa2fig1">Author response image 1.</xref></p>'
+            b'<p>4th <xref ref-type="fig" rid="sa2fig1">Author response image 1.</xref></p>'
+            b'</body>'
+        )
+        article_xml = ElementTree.fromstring(xml_string)
+        generate.asset_xref_tags(article_xml)
+        article_xml_string = ElementTree.tostring(article_xml)
+        self.assertEqual(article_xml_string, expected)
+
 
 class TestGenerateMaxLevel(unittest.TestCase):
 


### PR DESCRIPTION
An edge case in data for article `50209` used as a test uncovered a bug in the logic that adds `<xref>` tags in paragraph content where image or video labels are mentioned.

Here is the code fix and a new, elaborate test scenario that grew out of trying to debug it.

If tests are green I will merge.

Note, I also refactored some existing tests into separate files while I tried to track down where the bug was happening.