### PR TITLE
Edge case fix table parsing and paragraph append.

### DIFF
--- a/letterparser/build.py
+++ b/letterparser/build.py
@@ -492,7 +492,8 @@ def finish_wrap(content_blocks, content, appended_content, prev):
         content_blocks.append(
             ContentBlock("table-wrap", content_block_content, table_wrap_tag.attrib))
         prev['content'] = None
-        appended_content = content
+        if content and match_table_content_end(content):
+            appended_content = None
 
     return content_blocks, appended_content, prev
 

--- a/tests/test_build_content_sections.py
+++ b/tests/test_build_content_sections.py
@@ -115,6 +115,43 @@ class TestProcessContentSections(unittest.TestCase):
             '<caption><title>Author response table</title></caption>'
             '<table frame="hsides" rules="groups" />'))
 
+    def test_process_content_sections_table_paragraph_sandwich(self):
+        """test for edge case of table with regular paragraphs on either side"""
+        content_sections = [
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", 'Paragraph before.'),
+            ]),
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", '<bold>Author response Table 1.</bold>'),
+            ]),
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", (
+                    '&lt;Author response table 1 title/legend&gt;Author response table'
+                    '&lt;/Author response table 1 title/legend&gt;')),
+            ]),
+            OrderedDict([
+                ("tag_name", "table"),
+                ("content", '<table xmlns:mml="http://www.w3.org/1998/Math/MathML"></table>'),
+            ]),
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", 'Paragraph after.'),
+            ]),
+        ]
+        result = build.process_content_sections(content_sections, self.prefs)
+        self.assertEqual(result[0].block_type, "p")
+        self.assertEqual(result[0].content, "Paragraph before.")
+        self.assertEqual(result[1].block_type, "table-wrap")
+        self.assertEqual(result[1].content, (
+            '<label>Author response Table 1.</label>'
+            '<caption><title>Author response table</title></caption>'
+            '<table frame="hsides" rules="groups" />'))
+        self.assertEqual(result[2].block_type, "p")
+        self.assertEqual(result[2].content, "Paragraph after.")
+
     def test_process_content_sections_list(self):
         content_sections = [
             OrderedDict([


### PR DESCRIPTION
A bug observed when testing on a modified sample (based on an early sample named `eLife-23456.docx`). When there was a table preceeded by a regular paragraph, the table was repeated along with the content from the paragraph after the table.

This is a code fix for the `build.py` module and a test case is included for the situation.