### PR TITLE
Fix edge case collapsing new line on section name.

### DIFF
--- a/letterparser/utils.py
+++ b/letterparser/utils.py
@@ -54,6 +54,8 @@ def new_line_replace_with(line_one, line_two):
                 return "<break /><break />"
             elif not line_two.rstrip().endswith('</p>') and not line_one.startswith('<'):
                 return"<break /><break />"
+        elif line_one.rstrip().endswith('</bold><italic>') and not line_two.startswith('<'):
+            return "</italic><break /><break /><italic>"
         elif not line_one.rstrip().endswith('>') and not line_two.startswith('<'):
             return "<break /><break />"
     return ""
@@ -68,6 +70,8 @@ def collapse_newlines(string):
         replace_with = new_line_replace_with(prev_line, line.lstrip())
         new_string += replace_with + line.lstrip()
         prev_line = line
+    # remove meaningless italic tags due to and edge case fix
+    new_string = new_string.replace('<italic></italic>', '')
     return new_string
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -156,6 +156,14 @@ class TestCollapseNewlines(unittest.TestCase):
             "comment": "Tags before and after new line character",
             "string": "were calculated using</p>\n<p><disp-formula><alternatives>\n<tex-math>",
             "expected": "were calculated using</p><p><disp-formula><alternatives><tex-math>"
+        },
+        {
+            "comment": "New line after Author response section",
+            "string": (
+                "<p><bold>Author response</bold><italic>\nEssential revisions: ...</italic></p>"),
+            "expected": (
+                "<p><bold>Author response</bold><break /><break />"
+                "<italic>Essential revisions: ...</italic></p>")
         }
         )
     def test_collapse_newlines(self, test_data):


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5557

An issue with article `53580` decision letter where new line characters in the pandoc JATS output  immediately after an Author response section heading causes a parsing error.

This should be an isolated situation that will not have side effects, hopefully.