### PR TITLE
Improve collapsing new lines logic.

### DIFF
--- a/letterparser/utils.py
+++ b/letterparser/utils.py
@@ -53,8 +53,11 @@ def new_line_replace_with(line_one, line_two):
             if not line_two.rstrip().startswith('<') and line_two.rstrip().endswith('</p>'):
                 return "<break /><break />"
             elif not line_two.rstrip().endswith('</p>') and not line_one.startswith('<'):
-                return"<break /><break />"
-        elif line_one.rstrip().endswith('</bold><italic>') and not line_two.startswith('<'):
+                return "<break /><break />"
+        elif (
+                line_one.rstrip() != '<p><italic>'
+                and line_one.rstrip().endswith('<italic>')
+                and not line_two.startswith('<')):
             return "</italic><break /><break /><italic>"
         elif not line_one.rstrip().endswith('>') and not line_two.startswith('<'):
             return "<break /><break />"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -164,7 +164,17 @@ class TestCollapseNewlines(unittest.TestCase):
             "expected": (
                 "<p><bold>Author response</bold><break /><break />"
                 "<italic>Essential revisions: ...</italic></p>")
-        }
+        },
+        {
+            "comment": "New line after italic tag and before italic close tag",
+            "string": "<p>One<italic>\nTwo\n</italic></p>",
+            "expected": "<p>One<break /><break /><italic>Two</italic></p>"
+        },
+        {
+            "comment": "Italic paragraph with new line at beginning",
+            "string": "<p><italic> \nParagraph \n</italic></p>",
+            "expected": "<p><italic> Paragraph </italic></p>"
+        },
         )
     def test_collapse_newlines(self, test_data):
         new_string = utils.collapse_newlines(test_data.get("string"))


### PR DESCRIPTION
A bug in article `54519` input made visible an improvement to the logic that collapses new line characters into paragraphs. This satisfies existing tests, and new test cases make that coverage more easily testable in the future.