### PR TITLE
Edge case new line replace for Author response.

### DIFF
--- a/letterparser/utils.py
+++ b/letterparser/utils.py
@@ -61,6 +61,11 @@ def new_line_replace_with(line_one, line_two):
             return "</italic><break /><break /><italic>"
         elif not line_one.rstrip().endswith('>') and not line_two.startswith('<'):
             return "<break /><break />"
+        elif (
+                not line_one.rstrip().endswith('>')
+                and line_two.startswith('<bold>')
+                and line_two.endswith('</p>')):
+            return "<break /><break />"
     return ""
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -175,6 +175,11 @@ class TestCollapseNewlines(unittest.TestCase):
             "string": "<p><italic> \nParagraph \n</italic></p>",
             "expected": "<p><italic> Paragraph </italic></p>"
         },
+        {
+            "comment": "New line prior to bold section heading",
+            "string": "<p>Previous paragraph\n<bold>Author response</bold></p>",
+            "expected": "<p>Previous paragraph<break /><break /><bold>Author response</bold></p>"
+        },
         )
     def test_collapse_newlines(self, test_data):
         new_string = utils.collapse_newlines(test_data.get("string"))


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5610

An edge case observed where a new line character is prior to a bold **Author response** section heading. This will insert the `<break /><break />` in place of the new line character in this example. It again doesn't conflict with any existing test cases, and it is hopefully going in the right logical direction, where these edge cases will eventually all be collected and fixed.