### PR TITLE
Fix convert break tags ending in </disp-quote>

### DIFF
--- a/letterparser/parse.py
+++ b/letterparser/parse.py
@@ -140,7 +140,10 @@ def convert_break_tags(jats_content, root_tag="root"):
                     content += utils.close_tag(tag_name)
                     open_tags.add(tag_name)
 
-            if not content.endswith("</p>") and not content.endswith("</table>"):
+            if (
+                    not content.endswith("</p>")
+                    and not content.endswith("</table>")
+                    and not content.endswith("</disp-quote>")):
                 content += "</p>"
 
         converted_jats_content += content

--- a/tests/test_convert_break_tags.py
+++ b/tests/test_convert_break_tags.py
@@ -80,3 +80,13 @@ class TestConvertBreakTags(unittest.TestCase):
             '<table><tbody><tr><td></td></tr></tbody></table>')
         result = parse.convert_break_tags(jats_content)
         self.assertEqual(result, expected)
+
+    def test_convert_break_tags_disp_quote_edge_case(self):
+        jats_content = (
+            '<p><italic>Italic paragraph</italic></p>'
+            '<disp-quote><p>Disp quote paragraph.</p></disp-quote>')
+        expected = (
+            '<p><italic>Italic paragraph</italic></p><disp-quote>'
+            '<p>Disp quote paragraph.</p></disp-quote>')
+        result = parse.convert_break_tags(jats_content)
+        self.assertEqual(result, expected)

--- a/tests/test_convert_break_tags.py
+++ b/tests/test_convert_break_tags.py
@@ -86,7 +86,7 @@ class TestConvertBreakTags(unittest.TestCase):
             '<p><italic>Italic paragraph</italic></p>'
             '<disp-quote><p>Disp quote paragraph.</p></disp-quote>')
         expected = (
-            '<p><italic>Italic paragraph</italic></p><disp-quote>'
-            '<p>Disp quote paragraph.</p></disp-quote>')
+            '<p><italic>Italic paragraph</italic></p>'
+            '<disp-quote><p>Disp quote paragraph.</p></disp-quote>')
         result = parse.convert_break_tags(jats_content)
         self.assertEqual(result, expected)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5618

When converting break tags, there is an edge case for when content ends in `</disp-quote>` then do not add a `</p>` tag.