### PR TITLE
Fixes for collapsing new lines from recent articles

### DIFF
--- a/letterparser/utils.py
+++ b/letterparser/utils.py
@@ -52,10 +52,21 @@ def new_line_replace_with(line_one, line_two):
     line_two = line_two.lstrip().rstrip()
 
     if line_one.endswith('>') and line_two.startswith('<'):
+        if (
+                line_one.startswith('<p><italic>')
+                and not line_one.endswith('</italic></p>')
+                and line_two.startswith('</italic>')):
+            return "</italic><break /><break /><italic>"
+        # default return blank string
         return ""
     else:
         if not line_one.startswith('<p>'):
             if line_one.endswith('</italic>'):
+                return "<break /><break />"
+            elif (
+                    not line_one.startswith('<')
+                    and line_two.startswith('</italic>')
+                    and line_two != '</italic></p>'):
                 return "<break /><break />"
             elif not line_two.startswith('<') and line_two.endswith('</p>'):
                 return "<break /><break />"
@@ -92,6 +103,9 @@ def collapse_newlines(string):
     # remove meaningless break and italic tags due to and edge case fix
     new_string = new_string.replace(
         '<break /><break /></italic><break /><break />',
+        '</italic><break /><break />')
+    new_string = new_string.replace(
+        '<break /><break /></italic>',
         '</italic><break /><break />')
     new_string = new_string.replace(
         '<break /><break /><italic><break /><break />',

--- a/letterparser/utils.py
+++ b/letterparser/utils.py
@@ -93,6 +93,9 @@ def collapse_newlines(string):
     new_string = new_string.replace(
         '<break /><break /></italic><break /><break />',
         '</italic><break /><break />')
+    new_string = new_string.replace(
+        '<break /><break /><italic><break /><break />',
+        '<break /><break /><italic>')
     new_string = new_string.replace('<italic></italic>', '')
     return new_string
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -193,7 +193,7 @@ class TestCollapseNewlines(unittest.TestCase):
             "comment": "Italic open tag on its own line",
             "string": "<p>Paragraph\n<italic>\nItalic content</italic></p>",
             "expected": (
-                "<p>Paragraph<break /><break /><italic><break /><break />"
+                "<p>Paragraph<break /><break /><italic>"
                 "Italic content</italic></p>")
         },
         {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -237,6 +237,20 @@ class TestCollapseNewlines(unittest.TestCase):
                 "<break /><break /><disp-quote><p>Normal.</p>"
                 "<p><italic>Italic.</italic></p><p>Normal again.</p></disp-quote>")
         },
+        {
+            "comment": "italic close tag after a new line",
+            "string": (
+                "<p><italic>- How are the levels ....</p>\n"
+                "</italic>We include eosinophil numbers ....</p>\n"
+                "<p><italic>\n"
+                "I agree ....\n"
+                "</italic>We discuss our <italic>in vivo</italic> results ....</p>"),
+            "expected": (
+                "<p><italic>- How are the levels ....</p>"
+                "</italic><break /><break />We include eosinophil numbers ....</p>"
+                "<p><italic>I agree ....</italic><break /><break />"
+                "We discuss our <italic>in vivo</italic> results ....</p>")
+        },
         )
     def test_collapse_newlines(self, test_data):
         new_string = utils.collapse_newlines(test_data.get("string"))


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5676 described a couple of example articles where the new line characters were not split into paragraphs correctly, and sometimes there was also extra italic tags.

Code in this PR seems to fix these two errors, and it doesn't conflict with any existing test scenarios in the project. Hopefully these will be an improvement and not introduce new bugs into the parsing procedure.

There are a couple more additional glitches yet to fix, but it can be done separately, since they're not figured out yet.