### PR TITLE
More adaptive XML namespace de-dupe logic.

### DIFF
--- a/letterparser/generate.py
+++ b/letterparser/generate.py
@@ -239,7 +239,7 @@ def output_xml(root, pretty=False, indent=""):
     """output root XML Element to a string"""
     encoding = 'utf-8'
     rough_string = ElementTree.tostring(root, encoding)
-    rough_string = utils.xml_string_fix_namespaces(rough_string)
+    rough_string = utils.xml_string_fix_namespaces(rough_string, root.tag)
     reparsed = minidom.parseString(rough_string)
 
     if pretty is True:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -388,3 +388,38 @@ class TestReplaceCharacterEntities(unittest.TestCase):
         expected = b'&#x0022;Test&#x0022; &#x0026; &#x003C;&#x003E;'
         xml_string = utils.replace_character_entities(xml_string)
         self.assertEqual(xml_string, expected)
+
+
+class TestFixNamespaces(unittest.TestCase):
+
+    def setUp(self):
+        self.root_tag = 'root'
+
+    def test_fix_namespaces_blank(self):
+        xml_string = b''
+        expected = b''
+        self.assertEqual(utils.xml_string_fix_namespaces(xml_string, self.root_tag), expected)
+
+    def test_fix_namespaces_two_mml(self):
+        xml_string = (
+            b'<root xmlns:mml="http://www.w3.org/1998/Math/MathML"'
+            b' xmlns:ali="http://www.niso.org/schemas/ali/1.0/"'
+            b' xmlns:mml="http://www.w3.org/1998/Math/MathML"'
+            b' xmlns:xlink="http://www.w3.org/1999/xlink">')
+        expected = (
+            b'<root xmlns:ali="http://www.niso.org/schemas/ali/1.0/"'
+            b' xmlns:mml="http://www.w3.org/1998/Math/MathML"'
+            b' xmlns:xlink="http://www.w3.org/1999/xlink">')
+        self.assertEqual(utils.xml_string_fix_namespaces(xml_string, self.root_tag), expected)
+
+    def test_fix_namespaces_two_xlink(self):
+        xml_string = (
+            b'<root xmlns:xlink="http://www.w3.org/1999/xlink"'
+            b' xmlns:ali="http://www.niso.org/schemas/ali/1.0/"'
+            b' xmlns:mml="http://www.w3.org/1998/Math/MathML"'
+            b' xmlns:xlink="http://www.w3.org/1999/xlink">')
+        expected = (
+            b'<root xmlns:ali="http://www.niso.org/schemas/ali/1.0/"'
+            b' xmlns:mml="http://www.w3.org/1998/Math/MathML"'
+            b' xmlns:xlink="http://www.w3.org/1999/xlink">')
+        self.assertEqual(utils.xml_string_fix_namespaces(xml_string, self.root_tag), expected)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5696

Previously, there was only one XML which produced duplicate XML namespaces on the root tag when converted to a string. Today there was another, this time the `xmlns:xlink` namespace was the one duplicated.

Here, rather than accumulating each specific example of duplicate namespaces we observe, the logic is changed to programatically analyse the root tag attributes, de-duplicate the values, and replace the old tag string with the new tag string, as it did before.