### PR TITLE
Convert sec tags with a title from pandoc JATS.

### DIFF
--- a/letterparser/parse.py
+++ b/letterparser/parse.py
@@ -77,11 +77,31 @@ def best_jats(file_name, root_tag="root", config=None, temp_dir="tmp"):
     config = ensure_config(config)
     clean_jats_content = clean_jats(file_name, root_tag, config=config, temp_dir=temp_dir)
     clean_jats_content = utils.remove_strike(clean_jats_content)
-    jats_content = convert_break_tags(clean_jats_content, root_tag)
+    # convert sec tags
+    jats_content = convert_sec_tags(clean_jats_content)
+    # convert break tags
+    jats_content = convert_break_tags(jats_content, root_tag)
     # wrap in root_tag
     root_open_tag = "<" + root_tag + ">"
     root_close_tag = "</" + root_tag + ">"
     jats_content = root_open_tag + jats_content + root_close_tag
+    return jats_content
+
+
+def convert_sec_tags(jats_content):
+    """remove sec tags and convert title to p tag"""
+    match_string = r'(<sec.*?>.*</sec>)'
+    sec_tag_match = re.finditer(match_string, jats_content)
+    for match_group in sec_tag_match:
+        original_string = match_group.group(1)  # original string
+        # replace first title tag with p tag
+        new_string = re.sub(r'<sec.*?><title.*?>', '<p>', original_string)
+        new_string = re.sub(r'<sec.*?><title.*?>', '<p>', original_string)
+        new_string = re.sub(r'</title>', '</p>', new_string)
+        # remove sec close tag
+        new_string = re.sub(r'</sec>', '', new_string)
+        # replace in original string
+        jats_content = jats_content.replace(original_string, new_string)
     return jats_content
 
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -62,3 +62,18 @@ class TestParse(unittest.TestCase):
         jats_content = parse.best_jats(file_name, config=self.config)
         sections = parse.sections(jats_content)
         self.assertEqual(sections, expected)
+
+
+class TestConvertSecTags(unittest.TestCase):
+
+    def test_convert_sec_tags_blank(self):
+        jats_content = ''
+        expected = ''
+        converted_jats_content = parse.convert_sec_tags(jats_content)
+        self.assertEqual(converted_jats_content, expected)
+
+    def test_convert_sec_tags_sec_title(self):
+        jats_content = '<sec id="sec1"><title>Section title</title><p>Paragraph.</p></sec>'
+        expected = '<p>Section title</p><p>Paragraph.</p>'
+        converted_jats_content = parse.convert_sec_tags(jats_content)
+        self.assertEqual(converted_jats_content, expected)


### PR DESCRIPTION
Fixes https://github.com/elifesciences/issues/issues/5733

Brief summary is convert `<sec>` in pandoc JATS as a result of a `Heading 1` style specified in the `.docx` file. The sec's `<title>` tag is turned into a `<p>` tag.

Without this, the normal build and generate results in malformed XML.