### PR TITLE
Label string match for numbers greater than nine.

### DIFF
--- a/letterparser/build.py
+++ b/letterparser/build.py
@@ -541,7 +541,7 @@ def process_list_content(content, prev=None):
         utils.clean_portion(content, "list"), "list", content_xml.attrib, "add", prev.get('wrap'))
 
 
-FIG_CONTENT_START_PATTERN = r'\&lt;[A-Za-z ]+ image [0-9]?\&gt;'
+FIG_CONTENT_START_PATTERN = r'\&lt;[A-Za-z ]+ image [0-9]+?\&gt;'
 
 
 def match_fig_content_start(content):
@@ -549,27 +549,27 @@ def match_fig_content_start(content):
 
 
 def match_fig_content_title_start(content):
-    return bool(re.match(r'^&lt;.*image [0-9]? title\/legend\&gt;', content))
+    return bool(re.match(r'^&lt;.*image [0-9]+? title\/legend\&gt;', content))
 
 
 def match_fig_content_title_end(content):
-    return bool(re.match(r'.*\&lt;.*image [0-9]? title\/legend\&gt;$', content))
+    return bool(re.match(r'.*\&lt;.*image [0-9]+? title\/legend\&gt;$', content))
 
 
 def match_video_content_start(content):
-    return bool(re.match(r'\&lt;.*video [0-9]?\&gt;', content))
+    return bool(re.match(r'\&lt;.*video [0-9]+?\&gt;', content))
 
 
 def match_video_content_title_start(content):
-    return bool(re.match(r'^&lt;.*video [0-9]? title\/legend\&gt;', content))
+    return bool(re.match(r'^&lt;.*video [0-9]+? title\/legend\&gt;', content))
 
 
 def match_video_content_title_end(content):
-    return bool(re.match(r'.*\&lt;.*video [0-9]? title\/legend\&gt;$', content))
+    return bool(re.match(r'.*\&lt;.*video [0-9]+? title\/legend\&gt;$', content))
 
 
 def match_table_content_start(content):
-    return bool(re.match(r'^<bold>.*[tT]able [0-9]?.?<\/bold>$', content))
+    return bool(re.match(r'^<bold>.*[tT]able [0-9]+?.?<\/bold>$', content))
 
 
 def match_table_content_end(content):

--- a/tests/test_build_match.py
+++ b/tests/test_build_match.py
@@ -1,0 +1,55 @@
+# coding=utf-8
+
+import unittest
+from ddt import ddt, data
+from letterparser import build
+
+
+@ddt
+class TestMatchPatterns(unittest.TestCase):
+
+    @data(
+        {
+            "content": "",
+            "expected": False
+        },
+        {
+            "content": "&lt;Author response image 1&gt;",
+            "expected": True
+        },
+        {
+            "content": "content &lt;Author response image 1&gt;",
+            "expected": False
+        },
+        {
+            "content": "&lt;Decision letter image 666&gt;",
+            "expected": True
+        },
+    )
+    def test_match_fig_content_start(self, test_data):
+        self.assertEqual(
+            build.match_fig_content_start(test_data.get('content')),
+            test_data.get('expected'))
+
+    @data(
+        {
+            "content": "",
+            "expected": False
+        },
+        {
+            "content": "&lt;Author response image 1 title/legend&gt;",
+            "expected": True
+        },
+        {
+            "content": "content &lt;Author response image 1 title/legend&gt;",
+            "expected": False
+        },
+        {
+            "content": "&lt;Decision letter image 666 title/legend&gt;",
+            "expected": True
+        },
+    )
+    def test_match_fig_content_title_start(self, test_data):
+        self.assertEqual(
+            build.match_fig_content_title_start(test_data.get('content')),
+            test_data.get('expected'))


### PR DESCRIPTION
Fixes https://github.com/elifesciences/issues/issues/5767

A fairly straightforward bug when a `.docx` contained `Author response image 10`, and the matching pattern was only set to handle one digit in the numbering. Here, fix the match patterns to match any number.

I added a couple test cases, not for all the match patterns, but enough I hope to confirm it continues to function and is easy to diagnose errors.