### PR TITLE
Improve parsing fig with no caption followed by disp-quote

### DIFF
--- a/letterparser/build.py
+++ b/letterparser/build.py
@@ -627,7 +627,13 @@ def process_p_content(content, prev, prefs=None):
                 content = '%s%s' % (prev.get('content'), content)
                 action = 'add'
             else:
-                wrap = None
+                # after a fig with no caption, check if the next paragraph will be a disp-quote
+                if not match_disp_quote_content(content):
+                    wrap = None
+                else:
+                    wrap = 'disp-quote'
+                    content = clean_italic_p(content)
+                    action = "add"
         elif (wrap == 'media' and prev.get('content')
               and match_video_content_start(prev.get('content'))
               and not match_video_content_title_start(content)):

--- a/tests/test_build_content_sections.py
+++ b/tests/test_build_content_sections.py
@@ -339,6 +339,30 @@ class TestProcessContentSections(unittest.TestCase):
             '<label>Author response image 1</label><graphic mimetype="image" xlink:href="todo" />'))
         self.assertEqual(result[1].block_type, 'p')
 
+    def test_process_content_sections_image_no_title_editor_comment(self):
+        content_sections = [
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", '<p>&lt;Author response image 2&gt;</p>'),
+            ]),
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", '<p><italic>Editor comment paragraph.</italic></p>'),
+            ]),
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", '<p>Next regular paragraph.</p>'),
+            ]),
+        ]
+        result = build.process_content_sections(content_sections)
+        self.assertEqual(result[0].block_type, 'fig')
+        self.assertEqual(result[0].content, (
+            '<label>Author response image 2</label><graphic mimetype="image" xlink:href="todo" />'))
+        self.assertEqual(result[1].block_type, 'disp-quote')
+        self.assertEqual(result[1].content, '<p>Editor comment paragraph.</p>')
+        self.assertEqual(result[2].block_type, 'p')
+        self.assertEqual(result[2].content, 'Next regular paragraph.')
+
     def test_process_content_sections_video_no_title(self):
         content_sections = [
             OrderedDict([


### PR DESCRIPTION
Fixes https://github.com/elifesciences/issues/issues/5768

Includes a simple solution for if a fig has no caption, then the next non-caption paragraph test if it should be an editor comment `disp-quote` tag or not.

There is possibly some space for refactoring, where it could also check if the next paragraph is a table or a video, but until we see that case, this is a simple solution based on real data we've observed.