### PR TITLE
Fix collapse new line before bold section heading.

### DIFF
--- a/letterparser/utils.py
+++ b/letterparser/utils.py
@@ -70,6 +70,8 @@ def new_line_replace_with(line_one, line_two):
                     and line_two.startswith('</italic>')
                     and line_two != '</italic></p>'):
                 return "<break /><break />"
+            elif line_two.startswith('<bold>') and line_two.endswith('</bold></p>'):
+                return "<break /><break />"
             elif not line_two.startswith('<') and line_two.endswith('</p>'):
                 return "<break /><break />"
             elif not line_two.endswith('</p>') and not line_one.startswith('<'):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -324,6 +324,24 @@ class TestCollapseNewlines(unittest.TestCase):
                 "<p><italic>And why is σ<sub>h</sub> not shown beyond Figure 1?</italic></p>"
                 "<p>We have selected ...</p>")
         },
+        {
+            "comment": "new line before an Author response bold section",
+            "string": (
+                "<p>Paragraph.\n"
+                "Notation.\n"
+                "<bold>Author response</bold></p>\n"
+                "<p><italic>Reviewer #1:\n"
+                "My comments are the following:\n"
+                "...\n"
+                "</italic></p>"),
+            "expected": (
+                "<p>Paragraph.<break /><break />"
+                "Notation.<break /><break />"
+                "<bold>Author response</bold></p>"
+                "<p><italic>Reviewer #1:<break /><break />"
+                "My comments are the following:<break /><break />"
+                "...</italic></p>")
+        },
         )
     def test_collapse_newlines(self, test_data):
         new_string = utils.collapse_newlines(test_data.get("string"))


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5848, where another collapse new lines edge case was observed, and this PR fixes the situation.