### PR TITLE
Caption parsing fix and asset xref tag fix

### DIFF
--- a/letterparser/build.py
+++ b/letterparser/build.py
@@ -212,9 +212,9 @@ def extract_label_title_content(content):
         label_content = label_parts_match.group(1)
         return label_content, '', ''
 
-    parts_match = re.match(r'.*<bold>(.*?)</bold>(.*?)$', content)
-    label_content = parts_match.group(1)
-    remainder = parts_match.group(2)
+    parts_match = re.findall(r'<bold>(.*?)</bold>(.*)$', content)
+    label_content = parts_match[0][0]
+    remainder = ''.join(parts_match[0][1:])
     title_parts = remainder.split('.')
     title_label_match = r'^(.*)\&lt;.*\&gt;$'
     if len(title_parts) == 1:
@@ -230,7 +230,9 @@ def extract_label_title_content(content):
                 continue
             open_tag_count = title_content.count(utils.open_tag('italic'))
             close_tag_count = title_content.count(utils.close_tag('italic'))
-            if open_tag_count != close_tag_count:
+            open_bold_tag_count = title_content.count(utils.open_tag('bold'))
+            close_bold_tag_count = title_content.count(utils.close_tag('bold'))
+            if open_tag_count != close_tag_count or open_bold_tag_count != close_bold_tag_count:
                 title_content += title_part + '.'
             else:
                 content_remainders.append(title_part)

--- a/letterparser/generate.py
+++ b/letterparser/generate.py
@@ -275,7 +275,7 @@ def xml_string_asset_xref(xml_string, asset_labels):
     <xref ref-type="fig" rid="sa2fig1">Author response image 1A</xref> and B
     """
     for asset_label in asset_labels:
-        if asset_label.get('text') in str(xml_string):
+        if asset_label.get('text') and asset_label.get('text') in str(xml_string):
             attr = {'rid': asset_label.get('id'), 'ref-type': asset_label.get('type')}
             xref_open_tag = utils.open_tag('xref', attr)
             xref_close_tag = utils.close_tag('xref')

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -136,11 +136,11 @@ class TestExtractLabelTitleContent(unittest.TestCase):
         "edge case with more than one bold tag and second one is around the title full stop"
         content = (
             '<bold>Label</bold>The title<bold>.</bold> Another <bold>bold term</bold>.'
-            '&lt;/Legend&gt;')
+            'Another paragraph.&lt;/Legend&gt;')
         label, title, caption = build.extract_label_title_content(content)
         self.assertEqual(label, 'Label')
         self.assertEqual(title, 'The title<bold>.</bold> Another <bold>bold term</bold>.')
-        self.assertEqual(caption, '')
+        self.assertEqual(caption, 'Another paragraph.')
 
 
 class TestBuildFig(unittest.TestCase):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -132,6 +132,16 @@ class TestExtractLabelTitleContent(unittest.TestCase):
         self.assertEqual(title, 'In <italic>B. subtilis</italic>, the title.')
         self.assertEqual(caption, 'Caption.')
 
+    def test_two_bold_tags(self):
+        "edge case with more than one bold tag and second one is around the title full stop"
+        content = (
+            '<bold>Label</bold>The title<bold>.</bold> Another <bold>bold term</bold>.'
+            '&lt;/Legend&gt;')
+        label, title, caption = build.extract_label_title_content(content)
+        self.assertEqual(label, 'Label')
+        self.assertEqual(title, 'The title<bold>.</bold> Another <bold>bold term</bold>.')
+        self.assertEqual(caption, '')
+
 
 class TestBuildFig(unittest.TestCase):
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -423,6 +423,20 @@ class TestXmlStringAssetXref(unittest.TestCase):
                 '<xref ref-type="fig" rid="sa2fig1">Author response image 1A-D</xref></italic>.</p>'
             )
         },
+        {
+            'xml_string': (
+                '<p>Author response image 1A</p>'
+            ),
+            'asset_labels': [
+                OrderedDict([
+                    ('id', 'sa2fig1'),
+                    ('type', 'fig'),
+                    ('text', '')
+                ])],
+            'expected': (
+                '<p>Author response image 1A</p>'
+            )
+        },
     )
     def test_xml_string_asset_xref(self, test_data):
         modified_xml_string = generate.xml_string_asset_xref(


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/5874

A recent article failed to generate XML from the `.docx` file, the reasons centred around a figure caption, how it was parsed, and how the asset xref tag highlighting logic was confused by trying to search for a blank figure label in paragraph text.

Code here includes the fixes and two test cases for these situations.