### PR TITLE
Fix for fig with no legend followed by a table.

### DIFF
--- a/letterparser/build.py
+++ b/letterparser/build.py
@@ -649,9 +649,17 @@ def process_p_content(content, prev, prefs=None):
                 content = '%s%s' % (prev.get('content'), content)
                 action = 'add'
             else:
-                # after a fig with no caption, check if the next paragraph will be a disp-quote
+                # after a fig with no caption, check if the next paragraph
+                # is another type of wrap or will be a disp-quote
                 if not match_disp_quote_content(content):
-                    wrap = None
+                    if match_table_content_start(content):
+                        wrap = 'table-wrap'
+                        action = "add"
+                    elif match_video_content_start(content):
+                        wrap = 'media'
+                        action = "add"
+                    else:
+                        wrap = None
                 else:
                     wrap = 'disp-quote'
                     content = clean_italic_p(content)

--- a/tests/test_build_content_sections.py
+++ b/tests/test_build_content_sections.py
@@ -525,3 +525,49 @@ class TestProcessContentSections(unittest.TestCase):
         self.assertEqual(result[1].block_type, 'fig')
         self.assertEqual(result[1].content, (
             '<label>Author response image 2</label><graphic mimetype="image" xlink:href="todo" />'))
+
+    def test_process_content_sections_fig_then_table(self):
+        content_sections = [
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", '&lt;Author response image 1&gt;'),
+            ]),
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", '<bold>Author response table 1</bold>'),
+            ]),
+            OrderedDict([
+                ("tag_name", "table"),
+                ("content", '<table></table>'),
+            ]),
+        ]
+        result = build.process_content_sections(content_sections)
+        self.assertEqual(result[0].block_type, 'fig')
+        self.assertEqual(result[0].content, (
+            '<label>Author response image 1</label><graphic mimetype="image" xlink:href="todo" />'))
+        self.assertEqual(result[1].block_type, 'table-wrap')
+        self.assertEqual(result[1].content, (
+            '<label>Author response table 1</label><table frame="hsides" rules="groups" />'))
+
+    def test_process_content_sections_fig_then_media(self):
+        content_sections = [
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", '&lt;Author response image 1&gt;'),
+            ]),
+            OrderedDict([
+                ("tag_name", "p"),
+                ("content", '&lt;Author response video 1&gt;'),
+            ]),
+        ]
+        result = build.process_content_sections(content_sections)
+        self.assertEqual(result[0].block_type, 'fig')
+        self.assertEqual(result[0].content, (
+            '<label>Author response image 1</label><graphic mimetype="image" xlink:href="todo" />'))
+        self.assertEqual(result[1].block_type, 'media')
+        self.assertEqual(result[1].content, (
+            '<label>Author response video 1</label>'))
+        self.assertEqual(result[1].attr, {
+            'mimetype': 'video',
+            'xlink:href': 'todo'
+        })


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6050

A situation observed where a figure with no legend is immediately followed by a table. The code changes here will detect those properly, as well as any video followed immediately by a table.