### PR TITLE
Do not </p> after </list> in convert break tags.

### DIFF
--- a/letterparser/parse.py
+++ b/letterparser/parse.py
@@ -162,7 +162,8 @@ def convert_break_tags(jats_content, root_tag="root"):
             if (
                     not content.endswith("</p>")
                     and not content.endswith("</table>")
-                    and not content.endswith("</disp-quote>")):
+                    and not content.endswith("</disp-quote>")
+                    and not content.endswith("</list>")):
                 content += "</p>"
 
         converted_jats_content += content

--- a/tests/test_convert_break_tags.py
+++ b/tests/test_convert_break_tags.py
@@ -90,3 +90,13 @@ class TestConvertBreakTags(unittest.TestCase):
             '<disp-quote><p>Disp quote paragraph.</p></disp-quote>')
         result = parse.convert_break_tags(jats_content)
         self.assertEqual(result, expected)
+
+    def test_convert_break_tags_list_edge_case(self):
+        jats_content = (
+            '<p><italic>Italic paragraph</italic></p>'
+            '<list list-type="order"><list-item><p>One</p></list-item></list>')
+        expected = (
+            '<p><italic>Italic paragraph</italic></p>'
+            '<list list-type="order"><list-item><p>One</p></list-item></list>')
+        result = parse.convert_break_tags(jats_content)
+        self.assertEqual(result, expected)


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6212

As example of a list block in an article where the function that processes break tags is erroneously adding a `</p>` tag. The fix here is to not do that if the content ends in a `</list>` tag.