### PR TITLE
Allow a full stop at end of asset names.

### DIFF
--- a/letterparser/build.py
+++ b/letterparser/build.py
@@ -561,7 +561,7 @@ def process_list_content(content, prev=None):
         utils.clean_portion(content, "list"), "list", content_xml.attrib, "add", prev.get('wrap'))
 
 
-FIG_CONTENT_START_PATTERN = r'\&lt;[A-Za-z ]+ image [0-9]+?\&gt;'
+FIG_CONTENT_START_PATTERN = r'\&lt;[A-Za-z ]+ image [0-9]+?\.{0,1}\&gt;'
 
 
 def match_fig_content_start(content):
@@ -577,7 +577,7 @@ def match_fig_content_title_end(content):
 
 
 def match_video_content_start(content):
-    return bool(re.match(r'\&lt;.*video [0-9]+?\&gt;', content))
+    return bool(re.match(r'\&lt;.*video [0-9]+?\.{0,1}\&gt;', content))
 
 
 def match_video_content_title_start(content):

--- a/tests/test_build_match.py
+++ b/tests/test_build_match.py
@@ -25,6 +25,10 @@ class TestMatchPatterns(unittest.TestCase):
             "content": "&lt;Decision letter image 666&gt;",
             "expected": True
         },
+        {
+            "content": "content &lt;Author response image 2.&gt;",
+            "expected": False
+        },
     )
     def test_match_fig_content_start(self, test_data):
         self.assertEqual(
@@ -52,4 +56,31 @@ class TestMatchPatterns(unittest.TestCase):
     def test_match_fig_content_title_start(self, test_data):
         self.assertEqual(
             build.match_fig_content_title_start(test_data.get('content')),
+            test_data.get('expected'))
+
+    @data(
+        {
+            "content": "",
+            "expected": False
+        },
+        {
+            "content": "&lt;Author response video 1&gt;",
+            "expected": True
+        },
+        {
+            "content": "content &lt;Author response video 1&gt;",
+            "expected": False
+        },
+        {
+            "content": "&lt;Decision letter video 666&gt;",
+            "expected": True
+        },
+        {
+            "content": "content &lt;Author response video 2.&gt;",
+            "expected": False
+        },
+    )
+    def test_match_video_content_start(self, test_data):
+        self.assertEqual(
+            build.match_video_content_start(test_data.get('content')),
             test_data.get('expected'))


### PR DESCRIPTION
A result of issue https://github.com/elifesciences/issues/issues/5825 where a kitchen sink docx file is being finalised, this code will allow an optional full stop to be included in the angle bracketed mentions in the docx file. The full stop will carry through into the XML output in the `<label>` tag.