### PR TITLE
Fix new line break for italic tag on its own line.

### DIFF
--- a/letterparser/utils.py
+++ b/letterparser/utils.py
@@ -61,7 +61,9 @@ def new_line_replace_with(line_one, line_two):
         return ""
     else:
         if not line_one.startswith('<p>'):
-            if line_one.endswith('</italic>'):
+            if line_two == "<italic>":
+                return "<break /><break />"
+            elif line_one.endswith("</italic>"):
                 return "<break /><break />"
             elif line_one.startswith('</italic>') and line_two.startswith('<italic>'):
                 return "<break /><break />"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -371,3 +371,32 @@ class TestProcessP(unittest.TestCase):
         expected = ('blah blah&lt;/Author response video 1 title/legend&gt;',
                     'p', None, 'add', None)
         self.assertEqual(build.process_p_content(content, prev), expected)
+
+    def test_process_p_italic_inline_formula(self):
+        content = (
+            "<p><italic>2. The description ...</italic>"
+            "<inline-formula><alternatives>"
+            "<tex-math><![CDATA[- 2\\widetilde{v}]]></tex-math>"
+            '<mml:math display="inline" xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+            "<mml:mrow><mml:mo>−</mml:mo><mml:mn>2</mml:mn><mml:mover><mml:mi>v</mml:mi>"
+            '<mml:mo accent="true">∼</mml:mo></mml:mover></mml:mrow></mml:math>'
+            "</alternatives></inline-formula><italic>.</italic></p>"
+        )
+        prev = {}
+        prefs = {"italic_to_disp_quote": True}
+        expected = (
+            (
+                "<p>2. The description ..."
+                "<inline-formula><alternatives>"
+                "<tex-math><![CDATA[- 2\\widetilde{v}]]></tex-math>"
+                '<mml:math display="inline" xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+                "<mml:mrow><mml:mo>−</mml:mo><mml:mn>2</mml:mn><mml:mover><mml:mi>v</mml:mi>"
+                '<mml:mo accent="true">∼</mml:mo></mml:mover></mml:mrow></mml:math>'
+                "</alternatives></inline-formula>.</p>"
+            ),
+            "p",
+            None,
+            "add",
+            "disp-quote",
+        )
+        self.assertEqual(build.process_p_content(content, prev, prefs), expected)

--- a/tests/test_build_content_sections.py
+++ b/tests/test_build_content_sections.py
@@ -571,3 +571,99 @@ class TestProcessContentSections(unittest.TestCase):
             'mimetype': 'video',
             'xlink:href': 'todo'
         })
+
+    def test_process_content_sections_p_then_italic_inline_formula(self):
+        content_sections = [
+            OrderedDict(
+                [
+                    ("tag_name", "p"),
+                    (
+                        "content",
+                        (
+                            "The sign convention ... "
+                            "<inline-formula><alternatives>"
+                            "<tex-math><![CDATA[{\\widetilde{v}}_{i}]]></tex-math>"
+                            '<mml:math display="inline" '
+                            'xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+                            "<mml:msub><mml:mover><mml:mi>v</mml:mi>"
+                            '<mml:mo accent="true">∼</mml:mo>'
+                            "</mml:mover><mml:mi>i</mml:mi></mml:msub></mml:math>"
+                            "</alternatives></inline-formula> remains the same."
+                        ),
+                    ),
+                ]
+            ),
+            OrderedDict(
+                [
+                    ("tag_name", "p"),
+                    (
+                        "content",
+                        (
+                            "<italic>2. The description ...</italic> "
+                            "<inline-formula><alternatives>"
+                            "<tex-math><![CDATA[{2\\widetilde{v}}_{i}]]></tex-math>"
+                            '<mml:math display="inline" '
+                            'xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+                            "<mml:msub><mml:mrow><mml:mn>2</mml:mn><mml:mover><mml:mi>v</mml:mi>"
+                            '<mml:mo accent="true">∼</mml:mo>'
+                            "</mml:mover></mml:mrow><mml:mi>i</mml:mi></mml:msub></mml:math>"
+                            "</alternatives></inline-formula> "
+                            "<italic>-1? ...</italic> "
+                            "<inline-formula><alternatives>"
+                            "<tex-math><![CDATA[{2\\widetilde{v}}_{i}]]></tex-math>"
+                            '<mml:math display="inline" '
+                            'xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+                            "<mml:msub><mml:mrow><mml:mn>2</mml:mn><mml:mover><mml:mi>v</mml:mi>"
+                            '<mml:mo accent="true">∼</mml:mo>'
+                            "</mml:mover></mml:mrow><mml:mi>i</mml:mi></mml:msub></mml:math>"
+                            "</alternatives></inline-formula><italic>.</italic>"
+                        ),
+                    ),
+                ]
+            ),
+            OrderedDict(
+                [
+                    ("tag_name", "p"),
+                    ("content", "We thank the reviewer ...."),
+                ]
+            ),
+        ]
+        result = build.process_content_sections(content_sections)
+        self.assertEqual(result[0].block_type, "p")
+        self.assertEqual(
+            result[0].content,
+            (
+                "The sign convention ... "
+                "<inline-formula><alternatives>"
+                "<tex-math><![CDATA[{\\widetilde{v}}_{i}]]></tex-math>"
+                '<mml:math display="inline" xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+                "<mml:msub><mml:mover><mml:mi>v</mml:mi>"
+                '<mml:mo accent="true">∼</mml:mo>'
+                "</mml:mover><mml:mi>i</mml:mi></mml:msub></mml:math>"
+                "</alternatives></inline-formula> remains the same."
+            ),
+        )
+        self.assertEqual(result[1].block_type, "p")
+        self.assertEqual(
+            result[1].content,
+            (
+                "<italic>2. The description ...</italic> "
+                "<inline-formula><alternatives>"
+                "<tex-math><![CDATA[{2\\widetilde{v}}_{i}]]></tex-math>"
+                '<mml:math display="inline" xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+                "<mml:msub><mml:mrow><mml:mn>2</mml:mn><mml:mover><mml:mi>v</mml:mi>"
+                '<mml:mo accent="true">∼</mml:mo>'
+                "</mml:mover></mml:mrow><mml:mi>i</mml:mi></mml:msub></mml:math>"
+                "</alternatives></inline-formula> "
+                "<italic>-1? ...</italic> "
+                "<inline-formula><alternatives>"
+                "<tex-math><![CDATA[{2\\widetilde{v}}_{i}]]></tex-math>"
+                '<mml:math display="inline" xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+                "<mml:msub><mml:mrow><mml:mn>2</mml:mn><mml:mover><mml:mi>v</mml:mi>"
+                '<mml:mo accent="true">∼</mml:mo>'
+                "</mml:mover></mml:mrow><mml:mi>i</mml:mi></mml:msub></mml:math>"
+                "</alternatives></inline-formula><italic>.</italic>"
+            ),
+        )
+        self.assertEqual(result[2].block_type, "p")
+        self.assertEqual(result[2].content, ("We thank the reviewer ...."))

--- a/tests/test_build_match.py
+++ b/tests/test_build_match.py
@@ -84,3 +84,36 @@ class TestMatchPatterns(unittest.TestCase):
         self.assertEqual(
             build.match_video_content_start(test_data.get('content')),
             test_data.get('expected'))
+
+
+    @data(
+        {
+            "content": "",
+            "expected": False
+        },
+        {
+            "content": "<italic></italic>",
+            "expected": True
+        },
+        {
+            "content": "<italic> </italic> <italic> </italic>",
+            "expected": True
+        },
+        {
+            "content": (
+                '<italic>2. The description ...</italic>'
+                '<inline-formula><alternatives>'
+                '<tex-math><![CDATA[- 2\\widetilde{v}]]></tex-math>'
+                '<mml:math display="inline" xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+                '<mml:mrow><mml:mo>−</mml:mo><mml:mn>2</mml:mn>'
+                '<mml:mover><mml:mi>v</mml:mi><mml:mo accent="true">∼</mml:mo></mml:mover>'
+                '</mml:mrow></mml:math>'
+                '</alternatives></inline-formula>'
+                '<italic>.</italic>'),
+            "expected": True
+        },
+    )
+    def test_match_disp_quote_content(self, test_data):
+        self.assertEqual(
+            build.match_disp_quote_content(test_data.get('content')),
+            test_data.get('expected'))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -342,6 +342,45 @@ class TestCollapseNewlines(unittest.TestCase):
                 "My comments are the following:<break /><break />"
                 "...</italic></p>")
         },
+        {
+            "comment": "exact match of italic tag on one line",
+            "string": (
+                "<p>The sign ...\n"
+                "<inline-formula><alternatives>\n"
+                "<tex-math><![CDATA[{\\widetilde{v}}_{i}]]></tex-math>\n"
+                '<mml:math display="inline" xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+                "<mml:msub><mml:mover><mml:mi>v</mml:mi>"
+                '<mml:mo accent="true">∼</mml:mo>'
+                "</mml:mover><mml:mi>i</mml:mi></mml:msub>"
+                "</mml:math></alternatives></inline-formula> ....\n"
+                "<italic>\n"
+                "2. The description ...</italic>\n"
+                "<inline-formula><alternatives>\n"
+                "<tex-math><![CDATA[- 2\\widetilde{v}]]></tex-math>\n"
+                '<mml:math display="inline" xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+                "<mml:mrow><mml:mo>−</mml:mo><mml:mn>2</mml:mn><mml:mover><mml:mi>v</mml:mi>"
+                '<mml:mo accent="true">∼</mml:mo></mml:mover></mml:mrow>'
+                "</mml:math></alternatives></inline-formula><italic>.</italic></p>"
+            ),
+            "expected": (
+                "<p>The sign ..."
+                "<inline-formula><alternatives>"
+                "<tex-math><![CDATA[{\\widetilde{v}}_{i}]]></tex-math>"
+                '<mml:math display="inline" xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+                "<mml:msub><mml:mover><mml:mi>v</mml:mi>"
+                '<mml:mo accent="true">∼</mml:mo>'
+                "</mml:mover><mml:mi>i</mml:mi></mml:msub>"
+                "</mml:math></alternatives></inline-formula> ...."
+                "<break /><break />"
+                "<italic>2. The description ...</italic>"
+                "<inline-formula><alternatives>"
+                "<tex-math><![CDATA[- 2\\widetilde{v}]]></tex-math>"
+                '<mml:math display="inline" xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+                "<mml:mrow><mml:mo>−</mml:mo><mml:mn>2</mml:mn><mml:mover><mml:mi>v</mml:mi>"
+                '<mml:mo accent="true">∼</mml:mo></mml:mover></mml:mrow>'
+                "</mml:math></alternatives></inline-formula><italic>.</italic></p>"
+            ),
+        },
         )
     def test_collapse_newlines(self, test_data):
         new_string = utils.collapse_newlines(test_data.get("string"))


### PR DESCRIPTION
Re bug issue https://github.com/elifesciences/issues/issues/6581

eLife article `64740` decision letter had a bug parsing an author response editor comment paragraph containing inline formulae. The cause looked like due to a new line character prior to the italic paragraph was not considered to be a paragraph break in the decision letter parser logic, and as a result the italic paragraph was appended to the previous paragraph's content.

The code fix in this PR is in the `utils.py` module, and then there are some additional test scenarios added related to the bug. In addition, some tests for the `match_disp_quote_content()` function are a bonus, since as part of the troubleshooting process, it was tested more extensively.

There are no backwards compatibility problems anticipated in this PR, it is a bug fix only.