### PR TITLE
Enhance removal of complex scripts styles tags.

### DIFF
--- a/letterparser/utils.py
+++ b/letterparser/utils.py
@@ -260,8 +260,20 @@ def manuscript_from_file_name(file_name):
 
 def remove_complex_scripts_styles(document_xml):
     """given docx document.xml contents remove complex scripts style tags"""
-    # remove complex scripts bold style tags
-    document_xml = re.sub(rb'<w:bCs.*?/>', b'', document_xml)
-    # remove complex scripts italic style tags
-    document_xml = re.sub(rb'<w:iCs.*?/>', b'', document_xml)
-    return document_xml
+
+    # pattern for matching run tags w:r
+    run_tag_match_pattern = re.compile(rb"(<w:r\s+.*?>.*?</w:r>)")
+    # pattern for matching complex styles bold formatting tags
+    complex_bold_match_pattern = re.compile(rb"<w:bCs.*?/>")
+    # pattern for matching complex styles italic formatting tags
+    complex_italic_match_pattern = re.compile(rb"<w:iCs.*?/>")
+
+    new_document_xml = b""
+    for xml_part in re.split(run_tag_match_pattern, document_xml):
+        # if the w:rFonts tag contains a specific attribute, then do not remove the complex styles
+        if not (b"<w:rFonts" in xml_part and b"w:cstheme" in xml_part):
+            xml_part = re.sub(complex_bold_match_pattern, b"", xml_part)
+            xml_part = re.sub(complex_italic_match_pattern, b"", xml_part)
+        new_document_xml += xml_part
+
+    return new_document_xml

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -499,8 +499,25 @@ class TestRemoveComplexScriptsStyles(unittest.TestCase):
         self.assertEqual(xml_string, expected)
 
     def test_remove_complex_scripts_style_edge_cases(self):
-        xml_string = b'<w:iCs/><w:bCs><w:iCs w:val="false"/>'
-        expected = b''
+        xml_string = (
+            b'<w:pPr><w:r><w:rFonts w:cs="Calibri" w:ascii="Cambria" w:hAnsi="Cambria"'
+            b' w:asciiTheme="minorHAnsi" w:hAnsiTheme="minorHAnsi"/>'
+            b'<w:iCs/><w:bCs><w:iCs w:val="false"/></w:r></w:pPr>'
+        )
+        expected = (
+            b'<w:pPr><w:r><w:rFonts w:cs="Calibri" w:ascii="Cambria" w:hAnsi="Cambria"'
+            b' w:asciiTheme="minorHAnsi" w:hAnsiTheme="minorHAnsi"/>'
+            b'</w:r></w:pPr>'
+        )
+        xml_string = utils.remove_complex_scripts_styles(xml_string)
+        self.assertEqual(xml_string, expected)
+
+    def test_remove_complex_scripts_style_do_not_remove(self):
+        xml_string = (
+            b'<w:pPr><w:r id="a"><w:rFonts w:eastAsia="Times New Roman" w:cstheme="minorHAnsi"/>'
+            b'<w:iCs/><w:bCs><w:iCs w:val="false"/></w:r></w:pPr>'
+        )
+        expected = xml_string
         xml_string = utils.remove_complex_scripts_styles(xml_string)
         self.assertEqual(xml_string, expected)
 


### PR DESCRIPTION
Re bug issue https://github.com/elifesciences/issues/issues/6611

A decision letter had bold style removed from the `Decision letter` heading, which caused that section to be unrecognised. After investigation, it seemed like we can try to not remove the complex script style tags from the `.docx` file when it is "repaired" if the run contains a specific type of font tag.

In the end, the simplest solution was also the fastest: split the docx file's `word/document.xml` contents on each run tag (`<w:r>`), and then remove the complex script style tags on a run-by-run basis.