### PR TITLE
More precise run matching for complex styles tags.

### DIFF
--- a/letterparser/utils.py
+++ b/letterparser/utils.py
@@ -271,7 +271,9 @@ def remove_complex_scripts_styles(document_xml):
     new_document_xml = b""
     for xml_part in re.split(run_tag_match_pattern, document_xml):
         # if the w:rFonts tag contains a specific attribute, then do not remove the complex styles
-        if not (b"<w:rFonts" in xml_part and b"w:cstheme" in xml_part):
+        if not (b"<w:rFonts" in xml_part and b"w:cstheme" in xml_part) or (
+            b"<w:rFonts" in xml_part and b"w:cstheme" and b"w:ascii" in xml_part
+        ):
             xml_part = re.sub(complex_bold_match_pattern, b"", xml_part)
             xml_part = re.sub(complex_italic_match_pattern, b"", xml_part)
         new_document_xml += xml_part

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -512,6 +512,24 @@ class TestRemoveComplexScriptsStyles(unittest.TestCase):
         xml_string = utils.remove_complex_scripts_styles(xml_string)
         self.assertEqual(xml_string, expected)
 
+        # another example
+        xml_string = (
+            b'<w:r w:rsidRPr="000634ED">'
+            b'<w:rPr><w:rFonts w:ascii="Cambria" w:eastAsia="Times New Roman"'
+            b' w:hAnsi="Cambria" w:cstheme="minorHAnsi"/>'
+            b'<w:bCs/><w:lang w:val="en-US" w:eastAsia="en-GB"/>'
+            b'</w:rPr><w:t xml:space="preserve">The Introduction ....</w:t></w:r>'
+        )
+        expected = (
+            b'<w:r w:rsidRPr="000634ED">'
+            b'<w:rPr><w:rFonts w:ascii="Cambria" w:eastAsia="Times New Roman"'
+            b' w:hAnsi="Cambria" w:cstheme="minorHAnsi"/>'
+            b'<w:lang w:val="en-US" w:eastAsia="en-GB"/>'
+            b'</w:rPr><w:t xml:space="preserve">The Introduction ....</w:t></w:r>'
+        )
+        xml_string = utils.remove_complex_scripts_styles(xml_string)
+        self.assertEqual(xml_string, expected)
+
     def test_remove_complex_scripts_style_do_not_remove(self):
         xml_string = (
             b'<w:pPr><w:r id="a"><w:rFonts w:eastAsia="Times New Roman" w:cstheme="minorHAnsi"/>'


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6681

A couple examples where complex styles bold formatting shows up in the XML output where we do not want them to appear. By comparing the `.docx` XML with the other test case examples, it is possible to produce the desired output in all defined cases by looking for more complicated tag attribute matching rules of the `<w:rFonts>` tag.