### PR TITLE
Remove p tags which only contain whitespace.

### DIFF
--- a/letterparser/parse.py
+++ b/letterparser/parse.py
@@ -76,8 +76,10 @@ def best_jats(file_name, root_tag="root", config=None, temp_dir="tmp"):
     config = ensure_config(config)
     clean_jats_content = clean_jats(file_name, root_tag, config=config, temp_dir=temp_dir)
     clean_jats_content = utils.remove_strike(clean_jats_content)
+    # remove empty paragraphs
+    jats_content = utils.remove_empty_p_tags(clean_jats_content)
     # convert sec tags
-    jats_content = convert_sec_tags(clean_jats_content)
+    jats_content = convert_sec_tags(jats_content)
     # convert break tags
     jats_content = convert_break_tags(jats_content, root_tag)
     # wrap in root_tag

--- a/letterparser/utils.py
+++ b/letterparser/utils.py
@@ -42,6 +42,14 @@ def remove_strike(string):
     return string
 
 
+def remove_empty_p_tags(string):
+    """remove paragraphs which only contain whitespace"""
+    if not string:
+        return ""
+    empty_p_tag_match_pattern = re.compile(r"<p[^>]*?>\s+?</p>")
+    return re.sub(empty_p_tag_match_pattern, "", string)
+
+
 def new_line_replace_with(line_one, line_two):
     """determine the whitespace to use when concatenating two lines together"""
     if line_one is None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -97,6 +97,41 @@ class TestRemoveStrike(unittest.TestCase):
 
 
 @ddt
+class TestRemoveEmptyPTags(unittest.TestCase):
+    @data(
+        {"comment": "None value", "string": None, "expected": ""},
+        {"comment": "Basic string", "string": "string", "expected": "string"},
+        {
+            "comment": "Normal paragraph",
+            "string": "<p><italic>A normal paragraph.</italic></p>",
+            "expected": "<p><italic>A normal paragraph.</italic></p>",
+        },
+        {"comment": "One space character", "string": "<p> </p>", "expected": ""},
+        {
+            "comment": "Multiple whitespace characters",
+            "string": "<p> \t\t \n</p>",
+            "expected": "",
+        },
+        {
+            "comment": "Tag with attributes",
+            "string": '<p id="paragraph"> </p>',
+            "expected": "",
+        },
+    )
+    def test_remove_empty_p_tags(self, test_data):
+        new_string = utils.remove_empty_p_tags(test_data.get("string"))
+        self.assertEqual(
+            new_string,
+            test_data.get("expected"),
+            "{value} does not equal {expected}, scenario {comment}".format(
+                value=new_string,
+                expected=test_data.get("expected"),
+                comment=test_data.get("comment"),
+            ),
+        )
+
+
+@ddt
 class TestNewLineReplaceWith(unittest.TestCase):
 
     @data(


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6751

Parsing a `.docx` file resulted in an error when trying to match a table heading in the content. A line in the `.docx` file contained a single non-breaking space character, which resulted in a `<p> </p>` blank paragraph, and if it appears immediate after a table heading, then the current table matching pattern fails. Example content,

```xml
<p><bold>Author response table 1.</bold> </p>
<p> </p>
```

This PR adds an additional utils function, `remove_empty_p_tags()`, to remove any paragraphs which only contain whitespace, assuming these are unintentional and do not add any value to the output at this time.