### PR TITLE
Release pipeline configuration

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -1,0 +1,17 @@
+elifePipeline {
+
+    stage 'Checkout', {
+        checkout scm master
+    }
+    
+    stage 'Sandbox release', {
+        elifePypiRelease('test')
+    }
+    
+    stage 'Release', {
+        tag = elifePypiRelease()
+        elifeGitTagRevision(tag)
+    }
+    
+}
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # decision-letter-parser
-Parse docx file containing decision letter and author response content and produce output in other formats
+
+Parse docx file containing decision letter and author response content and produce output in other formats.
+
+The contents of the `.docx` must follow a specific formatting scheme for it to be separated out into multiple JATS XML `<sub-article>` tags, and for figure and table data to be recognised.
+
+## Requirements
+
+Parsing `.docx` files requires `pandoc`, and there are two options to make it available.
+
+1. Install [pandoc](https://pandoc.org/) so it can be executed locally, or
+2. Install [docker](https://www.docker.com/) and `pandoc` can be called using the `docker_image` specified in the `letterparser.cfg` configuration file
+
+## Example usage
+
+This library is meant to be integrated into another operational system, however the following are examples using interactive Python:
+
+Example 1 - Convert a test fixture zip containing a `.docx` and asset files
+
+```
+>>> from letterparser import generate
+>>> jats_xml = generate.generate_xml_from_file("tests/test_data/elife-00666.zip")
+```
+
+Example 2 - Convert just a `.docx` file only
+
+```
+>>> from letterparser import generate
+>>> jats_xml = generate.generate_xml_from_file("tests/test_data/elife-68041.docx")
+```
+
+## License
+
+Licensed under [MIT](https://opensource.org/licenses/mit-license.php).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 pypandoc==1.4
 pytest==2.9.1
 ddt==1.1.0
-git+https://github.com/elifesciences/elife-tools.git@aa63d17bed20bc039c12c4b0b371db6aedf0937a#egg=elifetools
-git+https://github.com/elifesciences/elife-article.git@230de0696fc43913558fbbb16e2a0c44fc04123f#egg=elifearticle
+elifetools==0.9.1
+elifearticle==0.4.0
 requests==2.22.0
 docker==4.0.2
 mock==1.3.0

--- a/setup.py
+++ b/setup.py
@@ -2,30 +2,32 @@ from setuptools import setup
 
 import letterparser
 
-with open('README.md') as fp:
+with open("README.md") as fp:
     readme = fp.read()
 
-setup(name='letterparser',
+setup(
+    name="letterparser",
     version=letterparser.__version__,
-    description='Decision letter and author response document parser.',
+    description="Decision letter and author response document parser.",
     long_description=readme,
-    packages=['letterparser'],
-    license = 'MIT',
+    long_description_content_type="text/markdown",
+    packages=["letterparser"],
+    license="MIT",
     install_requires=[
         "elifearticle",
         "elifetools",
         "pypandoc",
         "requests",
         "docker",
-        "configparser"
+        "configparser",
     ],
-    url='https://github.com/elifesciences/decision-letter-parser',
-    maintainer='eLife Sciences Publications Ltd.',
-    maintainer_email='tech-team@elifesciences.org',
+    url="https://github.com/elifesciences/decision-letter-parser",
+    maintainer="eLife Sciences Publications Ltd.",
+    maintainer_email="tech-team@elifesciences.org",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3"
-        ]
-    )
+        "Programming Language :: Python :: 3",
+    ],
+)


### PR DESCRIPTION
First attempt at configuring the library release pipeline, this will next go into the `master` branch, and then to configure the Jenkins pipeline.

Use server versioned libraries in the requirements.txt
Updated `setup.py` with the `long_description_content_type` value and linted it
Updated the readme
Added `Jenkinsfile.release`
 